### PR TITLE
[INIT][11/n] Fix PEM Parsing

### DIFF
--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -436,8 +436,8 @@ impl KalshiWsClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::KalshiEnvironment;
     use crate::ws::types::WsChannel;
-    use crate::{KalshiAuth, KalshiEnvironment};
     use tokio::time::Duration;
     use tokio_tungstenite::tungstenite::Message;
 
@@ -521,12 +521,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconnect_emits_reconnected_event() {
-        dotenvy::from_filename(".env.test").ok();
-        let auth = KalshiAuth::from_pem_file(
-            std::env::var("KALSHI_KEY_ID").expect("KALSHI_KEY_ID required"),
-            std::env::var("KALSHI_PRIVATE_KEY_PATH").expect("KALSHI_PRIVATE_KEY_PATH required"),
-        )
-        .expect("load auth");
+        let auth = crate::auth::tests::load_test_auth();
 
         let env = KalshiEnvironment::demo();
         let config = WsReconnectConfig {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,19 +8,20 @@ pub fn load_env() {
     dotenvy::from_filename(".env.test").ok();
 }
 
+// integration tests cannot import from unit tests
 #[allow(dead_code)]
 pub fn load_auth() -> KalshiAuth {
+    dotenvy::from_filename(".env.test").ok();
+
     let key_id = std::env::var("KALSHI_KEY_ID").expect("KALSHI_KEY_ID required");
 
-    // Try loading from content first (CI), then from file path (local dev)
     if let Ok(pem_content) = std::env::var("KALSHI_PRIVATE_KEY") {
-        // Unescape \n to real newlines (common in .env files and CI secrets)
         let pem_content = pem_content.replace("\\n", "\n");
-        KalshiAuth::from_pem_str(key_id, &pem_content).expect("Failed to load auth from content")
+        KalshiAuth::from_pem_str(key_id, &pem_content).expect("load auth from KALSHI_PRIVATE_KEY")
     } else {
         let pem_path = std::env::var("KALSHI_PRIVATE_KEY_PATH")
             .expect("KALSHI_PRIVATE_KEY or KALSHI_PRIVATE_KEY_PATH required");
-        KalshiAuth::from_pem_file(key_id, pem_path).expect("Failed to load auth from file")
+        KalshiAuth::from_pem_file(key_id, pem_path).expect("load auth from KALSHI_PRIVATE_KEY_PATH")
     }
 }
 


### PR DESCRIPTION
Refactored the test files to unescape `\n` characters in PEM content. This ensures compatibility with CI environments and `.env` files, improving overall test reliability.