### PR TITLE
v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0] - 2026-03-05
+
+### Added
+
+- Added `MarketStatusConversionError` for strict lifecycle/query status conversions.
+- Added best-effort `From` conversions between lifecycle `MarketStatus` and query `MarketStatusQuery`.
+- Added strict `TryFrom<&...>` conversions for exact one-to-one status mapping.
+- Added/expanded parsing tests for status serialization and conversion behavior.
+
+### Changed
+
+- Renamed query enum `MarketStatus` to `MarketStatusQuery`.
+- Renamed REST market lifecycle enum `MarketState` to `MarketStatus`.
+- Updated `GetMarketsParams.status` to use `Option<MarketStatusQuery>`.
+- Updated `Market.status` to use `Option<MarketStatus>`.
+- Updated examples, tests, and REST module docs to use the new names.
+
+### Breaking
+
+- Removed old `MarketState` and old query `MarketStatus` names without aliases.
+- Downstream consumers must update imports and enum references to the new names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added best-effort `From` conversions between lifecycle `MarketStatus` and query `MarketStatusQuery`.
 - Added strict `TryFrom<&...>` conversions for exact one-to-one status mapping.
 - Added/expanded parsing tests for status serialization and conversion behavior.
+- Added `KalshiError::Parse` with parse context, human-readable reason, raw payload bytes, and optional serde source error.
+- Added public parse accessors on `KalshiError`: `parse_context()`, `parse_error_reason()`, and `parse_raw_bytes()`.
+- Added regression tests covering REST and WebSocket parse failures to verify reason text and raw-byte preservation.
 
 ### Changed
 
@@ -23,8 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `GetMarketsParams.status` to use `Option<MarketStatusQuery>`.
 - Updated `Market.status` to use `Option<MarketStatus>`.
 - Updated examples, tests, and REST module docs to use the new names.
+- REST success-response decoding now returns `KalshiError::Parse` (with raw bytes) instead of a plain serde JSON error.
+- WebSocket envelope/message parsing now returns `KalshiError::Parse` with clearer parse-failure context and preserved raw payload bytes.
 
 ### Breaking
 
 - Removed old `MarketState` and old query `MarketStatus` names without aliases.
 - Downstream consumers must update imports and enum references to the new names.
+- Added a new `KalshiError` enum variant (`Parse`); downstream exhaustive `match` statements over `KalshiError` must handle this variant.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "kalshi-fast-rs"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kalshi-fast-rs"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 description = "High-performance async Rust client for Kalshi prediction markets API with full WebSocket support"
 license = "MIT"

--- a/examples/list_open_markets.rs
+++ b/examples/list_open_markets.rs
@@ -1,5 +1,5 @@
 /// Example of using the Public REST endpoints: lists open markets
-use kalshi_fast::{GetMarketsParams, KalshiEnvironment, KalshiRestClient, MarketStatus};
+use kalshi_fast::{GetMarketsParams, KalshiEnvironment, KalshiRestClient, MarketStatusQuery};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -9,7 +9,7 @@ async fn main() -> anyhow::Result<()> {
     let resp = client
         .get_markets(GetMarketsParams {
             limit: Some(1),
-            status: Some(MarketStatus::Open),
+            status: Some(MarketStatusQuery::Open),
             ..Default::default()
         })
         .await?;

--- a/examples/orderbook_stream.rs
+++ b/examples/orderbook_stream.rs
@@ -8,7 +8,7 @@
 /// Requires KALSHI_KEY_ID and KALSHI_PRIVATE_KEY_PATH env vars (or .env file)
 use kalshi_fast::{
     GetMarketsParams, KalshiAuth, KalshiEnvironment, KalshiRestClient, KalshiWsClient, Market,
-    MarketStatus, MveFilter, WsDataMessage, WsEvent, WsMessage, WsReconnectConfig,
+    MarketStatusQuery, MveFilter, WsDataMessage, WsEvent, WsMessage, WsReconnectConfig,
     WsSubscriptionParams,
 };
 use std::time::Duration;
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
         let resp = client
             .get_markets(GetMarketsParams {
                 limit: Some(100),
-                status: Some(MarketStatus::Open),
+                status: Some(MarketStatusQuery::Open),
                 mve_filter: Some(MveFilter::Exclude),
                 cursor: cursor.clone(),
                 ..Default::default()
@@ -90,7 +90,7 @@ async fn main() -> anyhow::Result<()> {
         .get_markets(GetMarketsParams {
             limit: Some(100),
             event_ticker: Some(vec![event_ticker.to_string()]),
-            status: Some(MarketStatus::Open),
+            status: Some(MarketStatusQuery::Open),
             ..Default::default()
         })
         .await?;

--- a/examples/place_order.rs
+++ b/examples/place_order.rs
@@ -3,7 +3,7 @@
 /// - Places an order
 use kalshi_fast::{
     BuySell, CreateOrderRequest, GetMarketsParams, KalshiAuth, KalshiEnvironment, KalshiRestClient,
-    MarketStatus, OrderType, YesNo,
+    MarketStatusQuery, OrderType, YesNo,
 };
 
 #[tokio::main]
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
     let resp = client
         .get_markets(GetMarketsParams {
             limit: Some(1),
-            status: Some(MarketStatus::Open),
+            status: Some(MarketStatusQuery::Open),
             ..Default::default()
         })
         .await?;

--- a/examples/resumable_market_scan.rs
+++ b/examples/resumable_market_scan.rs
@@ -2,7 +2,7 @@
 ///
 /// Demonstrates saving and restoring pagination state across sessions.
 /// Run multiple times to see it resume from the last checkpoint.
-use kalshi_fast::{GetMarketsParams, KalshiEnvironment, KalshiRestClient, MarketStatus};
+use kalshi_fast::{GetMarketsParams, KalshiEnvironment, KalshiRestClient, MarketStatusQuery};
 use std::fs;
 
 const CURSOR_FILE: &str = "/tmp/market_scan_cursor.txt";
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
 
     let mut pager = client.markets_pager(GetMarketsParams {
         cursor: start_cursor,
-        status: Some(MarketStatus::Open),
+        status: Some(MarketStatusQuery::Open),
         limit: Some(100),
         ..Default::default()
     });

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,15 @@ pub enum KalshiError {
     #[error(transparent)]
     Json(#[from] serde_json::Error),
 
+    #[error("parse error ({context}): {reason}")]
+    Parse {
+        context: String,
+        reason: String,
+        raw: Vec<u8>,
+        #[source]
+        source: Option<serde_json::Error>,
+    },
+
     #[error("crypto error: {0}")]
     Crypto(String),
 
@@ -37,4 +46,54 @@ pub enum KalshiError {
 
     #[error("websocket error: {0}")]
     Ws(String),
+}
+
+impl KalshiError {
+    pub(crate) fn parse_json(
+        context: impl Into<String>,
+        raw: impl AsRef<[u8]>,
+        source: serde_json::Error,
+    ) -> Self {
+        let reason = source.to_string();
+        Self::Parse {
+            context: context.into(),
+            reason,
+            raw: raw.as_ref().to_vec(),
+            source: Some(source),
+        }
+    }
+
+    pub(crate) fn parse_reason(
+        context: impl Into<String>,
+        raw: impl AsRef<[u8]>,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self::Parse {
+            context: context.into(),
+            reason: reason.into(),
+            raw: raw.as_ref().to_vec(),
+            source: None,
+        }
+    }
+
+    pub fn parse_context(&self) -> Option<&str> {
+        match self {
+            Self::Parse { context, .. } => Some(context),
+            _ => None,
+        }
+    }
+
+    pub fn parse_error_reason(&self) -> Option<&str> {
+        match self {
+            Self::Parse { reason, .. } => Some(reason),
+            _ => None,
+        }
+    }
+
+    pub fn parse_raw_bytes(&self) -> Option<&[u8]> {
+        match self {
+            Self::Parse { raw, .. } => Some(raw),
+            _ => None,
+        }
+    }
 }

--- a/src/rest/client.rs
+++ b/src/rest/client.rs
@@ -727,7 +727,13 @@ impl KalshiRestClient {
                         } else {
                             bytes.as_ref()
                         };
-                        return Ok(serde_json::from_slice::<T>(body_bytes)?);
+                        return serde_json::from_slice::<T>(body_bytes).map_err(|source| {
+                            KalshiError::parse_json(
+                                format!("REST {} {}", method, full_path),
+                                body_bytes,
+                                source,
+                            )
+                        });
                     }
 
                     let should_retry = retry_number < self.retry_config.max_retries
@@ -2717,6 +2723,43 @@ mod tests {
             }
             other => panic!("unexpected error: {:?}", other),
         }
+    }
+
+    #[tokio::test]
+    async fn rest_success_parse_error_exposes_raw_bytes_and_reason() {
+        let body = r#"{"exchange_active":"true","trading_active":true}"#;
+        let (rest_origin, _hits, server) =
+            spawn_http_sequence_server(vec![TestHttpResponse::new(StatusCode::OK, body)]).await;
+
+        let client = KalshiRestClient::builder(test_env(rest_origin))
+            .build()
+            .expect("build client");
+
+        let err = client
+            .get_exchange_status()
+            .await
+            .expect_err("invalid response schema should fail");
+        match err {
+            KalshiError::Parse {
+                context,
+                reason,
+                raw,
+                ..
+            } => {
+                assert_eq!(
+                    context,
+                    format!(
+                        "REST GET {}",
+                        KalshiRestClient::full_path("/exchange/status")
+                    )
+                );
+                assert_eq!(raw, body.as_bytes());
+                assert!(reason.contains("invalid type"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+
+        server.await.expect("server").expect("server ok");
     }
 
     #[test]

--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -32,7 +32,7 @@
 //! ```no_run
 //! use kalshi_fast::{
 //!     GetMarketsParams, KalshiAuth, KalshiEnvironment,
-//!     KalshiRestClient, MarketStatus,
+//!     KalshiRestClient, MarketStatusQuery,
 //! };
 //!
 //! # async fn run() -> Result<(), kalshi_fast::KalshiError> {
@@ -44,7 +44,7 @@
 //! // Public endpoint — no auth needed
 //! let resp = client
 //!     .get_markets(GetMarketsParams {
-//!         status: Some(MarketStatus::Open),
+//!         status: Some(MarketStatusQuery::Open),
 //!         limit: Some(5),
 //!         ..Default::default()
 //!     })

--- a/src/rest/types.rs
+++ b/src/rest/types.rs
@@ -1,12 +1,13 @@
 use crate::error::KalshiError;
 use crate::types::{
-    BuySell, ErrorResponse, EventStatus, FeeType, FixedPointCount, FixedPointDollars, MarketStatus,
-    MveFilter, OrderStatus, OrderType, PositionCountFilter, SelfTradePreventionType, TimeInForce,
-    TradeTakerSide, YesNo, deserialize_null_as_empty_vec, deserialize_string_or_number,
-    serialize_csv_opt,
+    BuySell, ErrorResponse, EventStatus, FeeType, FixedPointCount, FixedPointDollars,
+    MarketStatusQuery, MveFilter, OrderStatus, OrderType, PositionCountFilter,
+    SelfTradePreventionType, TimeInForce, TradeTakerSide, YesNo, deserialize_null_as_empty_vec,
+    deserialize_string_or_number, serialize_csv_opt,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use std::fmt;
 
 /// --- Series ---
 
@@ -282,9 +283,9 @@ pub struct GetEventResponse {
 
 /// --- Markets ---
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum MarketState {
+pub enum MarketStatus {
     Initialized,
     Inactive,
     Active,
@@ -295,6 +296,117 @@ pub enum MarketState {
     Finalized,
     #[serde(other)]
     Unknown,
+}
+
+impl MarketStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            MarketStatus::Initialized => "initialized",
+            MarketStatus::Inactive => "inactive",
+            MarketStatus::Active => "active",
+            MarketStatus::Closed => "closed",
+            MarketStatus::Determined => "determined",
+            MarketStatus::Disputed => "disputed",
+            MarketStatus::Amended => "amended",
+            MarketStatus::Finalized => "finalized",
+            MarketStatus::Unknown => "unknown",
+        }
+    }
+}
+
+/// Error returned by strict lifecycle/query status conversions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarketStatusConversionError {
+    LifecycleToQuery(MarketStatus),
+    QueryToLifecycle(MarketStatusQuery),
+}
+
+impl fmt::Display for MarketStatusConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MarketStatusConversionError::LifecycleToQuery(status) => write!(
+                f,
+                "cannot strictly convert lifecycle market status `{}` to market status query",
+                status.as_str()
+            ),
+            MarketStatusConversionError::QueryToLifecycle(status) => write!(
+                f,
+                "cannot strictly convert market status query `{}` to lifecycle market status",
+                status.as_str()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for MarketStatusConversionError {}
+
+/// Best-effort compatibility conversion between response lifecycle status and
+/// query status filters.
+///
+/// Prefer using the source enum directly when possible. This mapping is lossy.
+impl From<MarketStatus> for MarketStatusQuery {
+    fn from(status: MarketStatus) -> Self {
+        match status {
+            MarketStatus::Initialized => MarketStatusQuery::Unopened,
+            MarketStatus::Inactive => MarketStatusQuery::Paused,
+            MarketStatus::Active => MarketStatusQuery::Open,
+            MarketStatus::Closed => MarketStatusQuery::Closed,
+            MarketStatus::Determined => MarketStatusQuery::Closed,
+            MarketStatus::Disputed => MarketStatusQuery::Closed,
+            MarketStatus::Amended => MarketStatusQuery::Closed,
+            MarketStatus::Finalized => MarketStatusQuery::Settled,
+            MarketStatus::Unknown => MarketStatusQuery::Unknown,
+        }
+    }
+}
+
+/// Best-effort compatibility conversion between query status filters and
+/// response lifecycle status.
+///
+/// Prefer using the source enum directly when possible. This mapping is lossy.
+impl From<MarketStatusQuery> for MarketStatus {
+    fn from(status: MarketStatusQuery) -> Self {
+        match status {
+            MarketStatusQuery::Unopened => MarketStatus::Initialized,
+            MarketStatusQuery::Open => MarketStatus::Active,
+            MarketStatusQuery::Paused => MarketStatus::Inactive,
+            MarketStatusQuery::Closed => MarketStatus::Closed,
+            MarketStatusQuery::Settled => MarketStatus::Finalized,
+            MarketStatusQuery::Unknown => MarketStatus::Unknown,
+        }
+    }
+}
+
+/// Strict lifecycle-to-query conversion helper.
+///
+/// Prefer direct enum usage whenever possible. This exists for forward
+/// compatibility and only succeeds for one-to-one status values.
+impl TryFrom<&MarketStatus> for MarketStatusQuery {
+    type Error = MarketStatusConversionError;
+
+    fn try_from(status: &MarketStatus) -> Result<Self, Self::Error> {
+        match *status {
+            MarketStatus::Closed => Ok(MarketStatusQuery::Closed),
+            MarketStatus::Unknown => Ok(MarketStatusQuery::Unknown),
+            _ => Err(MarketStatusConversionError::LifecycleToQuery(*status)),
+        }
+    }
+}
+
+/// Strict query-to-lifecycle conversion helper.
+///
+/// Prefer direct enum usage whenever possible. This exists for forward
+/// compatibility and only succeeds for one-to-one status values.
+impl TryFrom<&MarketStatusQuery> for MarketStatus {
+    type Error = MarketStatusConversionError;
+
+    fn try_from(status: &MarketStatusQuery) -> Result<Self, Self::Error> {
+        match *status {
+            MarketStatusQuery::Closed => Ok(MarketStatus::Closed),
+            MarketStatusQuery::Unknown => Ok(MarketStatus::Unknown),
+            _ => Err(MarketStatusConversionError::QueryToLifecycle(*status)),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -329,7 +441,7 @@ pub struct Market {
     #[serde(default)]
     pub market_id: Option<String>,
     #[serde(default)]
-    pub status: Option<MarketState>,
+    pub status: Option<MarketStatus>,
     #[serde(default)]
     pub market_type: Option<String>,
     #[serde(default)]
@@ -539,7 +651,7 @@ pub struct GetMarketsParams {
 
     /// Only one status filter may be supplied at a time.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<MarketStatus>,
+    pub status: Option<MarketStatusQuery>,
 
     /// Market tickers comma-separated.
     #[serde(
@@ -610,7 +722,11 @@ impl GetMarketsParams {
         if created
             && matches!(
                 self.status,
-                Some(MarketStatus::Closed | MarketStatus::Settled | MarketStatus::Paused)
+                Some(
+                    MarketStatusQuery::Closed
+                        | MarketStatusQuery::Settled
+                        | MarketStatusQuery::Paused
+                )
             )
         {
             return Err(KalshiError::InvalidParams(
@@ -621,10 +737,10 @@ impl GetMarketsParams {
             && matches!(
                 self.status,
                 Some(
-                    MarketStatus::Unopened
-                        | MarketStatus::Open
-                        | MarketStatus::Settled
-                        | MarketStatus::Paused
+                    MarketStatusQuery::Unopened
+                        | MarketStatusQuery::Open
+                        | MarketStatusQuery::Settled
+                        | MarketStatusQuery::Paused
                 )
             )
         {
@@ -636,10 +752,10 @@ impl GetMarketsParams {
             && matches!(
                 self.status,
                 Some(
-                    MarketStatus::Unopened
-                        | MarketStatus::Open
-                        | MarketStatus::Closed
-                        | MarketStatus::Paused
+                    MarketStatusQuery::Unopened
+                        | MarketStatusQuery::Open
+                        | MarketStatusQuery::Closed
+                        | MarketStatusQuery::Paused
                 )
             )
         {

--- a/src/types.rs
+++ b/src/types.rs
@@ -176,11 +176,11 @@ impl Serialize for EventStatus {
     }
 }
 
-/// --- Market Status ---
+/// --- Market Status Query ---
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum MarketStatus {
+pub enum MarketStatusQuery {
     Unopened,
     Open,
     Paused,
@@ -190,26 +190,26 @@ pub enum MarketStatus {
     Unknown,
 }
 
-impl MarketStatus {
+impl MarketStatusQuery {
     pub fn as_str(self) -> &'static str {
         match self {
-            MarketStatus::Unopened => "unopened",
-            MarketStatus::Open => "open",
-            MarketStatus::Paused => "paused",
-            MarketStatus::Closed => "closed",
-            MarketStatus::Settled => "settled",
-            MarketStatus::Unknown => "unknown",
+            MarketStatusQuery::Unopened => "unopened",
+            MarketStatusQuery::Open => "open",
+            MarketStatusQuery::Paused => "paused",
+            MarketStatusQuery::Closed => "closed",
+            MarketStatusQuery::Settled => "settled",
+            MarketStatusQuery::Unknown => "unknown",
         }
     }
 }
 
-impl fmt::Display for MarketStatus {
+impl fmt::Display for MarketStatusQuery {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
-impl Serialize for MarketStatus {
+impl Serialize for MarketStatusQuery {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(self.as_str())
     }
@@ -511,14 +511,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn market_status_deserialize_known() {
-        let status: MarketStatus = serde_json::from_str("\"open\"").unwrap();
-        assert!(matches!(status, MarketStatus::Open));
+    fn market_status_query_deserialize_known() {
+        let status: MarketStatusQuery = serde_json::from_str("\"open\"").unwrap();
+        assert!(matches!(status, MarketStatusQuery::Open));
     }
 
     #[test]
-    fn market_status_deserialize_unknown() {
-        let status: MarketStatus = serde_json::from_str("\"mystery\"").unwrap();
-        assert!(matches!(status, MarketStatus::Unknown));
+    fn market_status_query_deserialize_unknown() {
+        let status: MarketStatusQuery = serde_json::from_str("\"mystery\"").unwrap();
+        assert!(matches!(status, MarketStatusQuery::Unknown));
     }
 }

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -484,7 +484,8 @@ impl KalshiWsLowLevelClient {
     /// Close frames or stream termination.
     pub async fn next_envelope(&mut self) -> Result<WsEnvelope, KalshiError> {
         let bytes = self.next_json_bytes().await?;
-        Ok(serde_json::from_slice::<WsEnvelope>(&bytes)?)
+        serde_json::from_slice::<WsEnvelope>(&bytes)
+            .map_err(|source| KalshiError::parse_json("websocket envelope", &bytes, source))
     }
 
     /// Read the next message and parse it into a typed [`WsMessage`].

--- a/src/ws/types.rs
+++ b/src/ws/types.rs
@@ -3054,9 +3054,21 @@ impl WsMessage {
             Ok(wire) => Ok(wire.into_message()),
             Err(first_err) => match serde_json::from_slice::<WsEnvelope>(bytes) {
                 Ok(env) => env.into_message(),
-                Err(_) => Err(first_err.into()),
+                Err(second_err) => Err(KalshiError::parse_reason(
+                    "websocket message",
+                    bytes,
+                    format!(
+                        "failed to parse as WsWireMessage ({first_err}); failed to parse as WsEnvelope ({second_err})"
+                    ),
+                )),
             },
         }
+        .map_err(|err| match err {
+            KalshiError::Json(source) => {
+                KalshiError::parse_json("websocket message payload", bytes, source)
+            }
+            other => other,
+        })
     }
 }
 
@@ -3066,9 +3078,21 @@ impl<'a> WsMessageRef<'a> {
             Ok(wire) => Ok(wire.into_message()),
             Err(first_err) => match serde_json::from_slice::<WsEnvelopeRef<'a>>(bytes) {
                 Ok(env) => env.into_message(),
-                Err(_) => Err(first_err.into()),
+                Err(second_err) => Err(KalshiError::parse_reason(
+                    "websocket borrowed message",
+                    bytes,
+                    format!(
+                        "failed to parse as WsWireMessageRef ({first_err}); failed to parse as WsEnvelopeRef ({second_err})"
+                    ),
+                )),
             },
         }
+        .map_err(|err| match err {
+            KalshiError::Json(source) => {
+                KalshiError::parse_json("websocket borrowed message payload", bytes, source)
+            }
+            other => other,
+        })
     }
 }
 
@@ -3252,6 +3276,38 @@ mod tests {
             }
             _ => panic!("expected unknown message"),
         }
+    }
+
+    #[test]
+    fn ws_message_from_bytes_invalid_json_exposes_raw_bytes_and_reason() {
+        let raw = br#"{"type":"ticker","msg":{"market_ticker":"TEST"}"#;
+        let err = WsMessage::from_bytes(raw).expect_err("invalid JSON should fail");
+        match err {
+            KalshiError::Parse {
+                context,
+                reason,
+                raw: parse_raw,
+                ..
+            } => {
+                assert_eq!(context, "websocket message");
+                assert_eq!(parse_raw.as_slice(), raw);
+                assert!(reason.contains("failed to parse as WsWireMessage"));
+                assert!(reason.contains("failed to parse as WsEnvelope"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ws_message_from_bytes_payload_parse_error_exposes_raw_bytes_and_reason() {
+        let raw = br#"{"type":"ticker","sid":1,"seq":2,"msg":{"market_ticker":"TEST"}}"#;
+        let err = WsMessage::from_bytes(raw).expect_err("invalid payload should fail");
+        assert_eq!(err.parse_context(), Some("websocket message payload"));
+        assert_eq!(err.parse_raw_bytes(), Some(&raw[..]));
+        let reason = err
+            .parse_error_reason()
+            .expect("parse errors should include a reason");
+        assert!(reason.contains("missing field"));
     }
 
     #[test]

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -10,8 +10,8 @@ use kalshi_fast::{
     GetSeriesFeeChangesResponse, GetSettlementsParams, GetSettlementsResponse,
     GetSubaccountBalancesResponse, GetSubaccountTransfersParams, GetSubaccountTransfersResponse,
     GetTradesParams, GetTradesResponse, GetUserDataTimestampResponse, MarketMetadata, MarketStatus,
-    MveFilter, OrderStatus, OrderType, PositionCountFilter, PriceRange, SelfTradePreventionType,
-    TimeInForce, YesNo,
+    MarketStatusConversionError, MarketStatusQuery, MveFilter, OrderStatus, OrderType,
+    PositionCountFilter, PriceRange, SelfTradePreventionType, TimeInForce, YesNo,
 };
 
 // ============================================================================
@@ -19,27 +19,133 @@ use kalshi_fast::{
 // ============================================================================
 
 #[test]
-fn market_status_serializes_correctly() {
+fn market_status_query_serializes_correctly() {
     assert_eq!(
-        serde_json::to_string(&MarketStatus::Open).unwrap(),
+        serde_json::to_string(&MarketStatusQuery::Open).unwrap(),
         "\"open\""
     );
     assert_eq!(
-        serde_json::to_string(&MarketStatus::Closed).unwrap(),
+        serde_json::to_string(&MarketStatusQuery::Closed).unwrap(),
         "\"closed\""
     );
     assert_eq!(
-        serde_json::to_string(&MarketStatus::Settled).unwrap(),
+        serde_json::to_string(&MarketStatusQuery::Settled).unwrap(),
         "\"settled\""
     );
     assert_eq!(
-        serde_json::to_string(&MarketStatus::Paused).unwrap(),
+        serde_json::to_string(&MarketStatusQuery::Paused).unwrap(),
         "\"paused\""
     );
     assert_eq!(
-        serde_json::to_string(&MarketStatus::Unopened).unwrap(),
+        serde_json::to_string(&MarketStatusQuery::Unopened).unwrap(),
         "\"unopened\""
     );
+}
+
+#[test]
+fn market_status_from_lifecycle_is_best_effort() {
+    assert_eq!(
+        MarketStatusQuery::from(MarketStatus::Initialized),
+        MarketStatusQuery::Unopened
+    );
+    assert_eq!(
+        MarketStatusQuery::from(MarketStatus::Inactive),
+        MarketStatusQuery::Paused
+    );
+    assert_eq!(
+        MarketStatusQuery::from(MarketStatus::Active),
+        MarketStatusQuery::Open
+    );
+    assert_eq!(
+        MarketStatusQuery::from(MarketStatus::Closed),
+        MarketStatusQuery::Closed
+    );
+    assert_eq!(
+        MarketStatusQuery::from(MarketStatus::Determined),
+        MarketStatusQuery::Closed
+    );
+    assert_eq!(
+        MarketStatusQuery::from(MarketStatus::Disputed),
+        MarketStatusQuery::Closed
+    );
+    assert_eq!(
+        MarketStatusQuery::from(MarketStatus::Amended),
+        MarketStatusQuery::Closed
+    );
+    assert_eq!(
+        MarketStatusQuery::from(MarketStatus::Finalized),
+        MarketStatusQuery::Settled
+    );
+    assert_eq!(
+        MarketStatusQuery::from(MarketStatus::Unknown),
+        MarketStatusQuery::Unknown
+    );
+}
+
+#[test]
+fn market_status_from_query_is_best_effort() {
+    assert_eq!(
+        MarketStatus::from(MarketStatusQuery::Unopened),
+        MarketStatus::Initialized
+    );
+    assert_eq!(
+        MarketStatus::from(MarketStatusQuery::Open),
+        MarketStatus::Active
+    );
+    assert_eq!(
+        MarketStatus::from(MarketStatusQuery::Paused),
+        MarketStatus::Inactive
+    );
+    assert_eq!(
+        MarketStatus::from(MarketStatusQuery::Closed),
+        MarketStatus::Closed
+    );
+    assert_eq!(
+        MarketStatus::from(MarketStatusQuery::Settled),
+        MarketStatus::Finalized
+    );
+    assert_eq!(
+        MarketStatus::from(MarketStatusQuery::Unknown),
+        MarketStatus::Unknown
+    );
+}
+
+#[test]
+fn market_status_query_try_from_lifecycle_is_strict() {
+    assert_eq!(
+        MarketStatusQuery::try_from(&MarketStatus::Closed).unwrap(),
+        MarketStatusQuery::Closed
+    );
+    assert_eq!(
+        MarketStatusQuery::try_from(&MarketStatus::Unknown).unwrap(),
+        MarketStatusQuery::Unknown
+    );
+
+    assert!(matches!(
+        MarketStatusQuery::try_from(&MarketStatus::Active),
+        Err(MarketStatusConversionError::LifecycleToQuery(
+            MarketStatus::Active
+        ))
+    ));
+}
+
+#[test]
+fn market_status_try_from_query_is_strict() {
+    assert_eq!(
+        MarketStatus::try_from(&MarketStatusQuery::Closed).unwrap(),
+        MarketStatus::Closed
+    );
+    assert_eq!(
+        MarketStatus::try_from(&MarketStatusQuery::Unknown).unwrap(),
+        MarketStatus::Unknown
+    );
+
+    assert!(matches!(
+        MarketStatus::try_from(&MarketStatusQuery::Open),
+        Err(MarketStatusConversionError::QueryToLifecycle(
+            MarketStatusQuery::Open
+        ))
+    ));
 }
 
 #[test]
@@ -143,7 +249,7 @@ fn self_trade_prevention_type_serializes_correctly() {
 fn get_markets_params_serializes_with_csv_fields() {
     let params = GetMarketsParams {
         limit: Some(50),
-        status: Some(MarketStatus::Open),
+        status: Some(MarketStatusQuery::Open),
         event_ticker: Some(vec!["EVT1".into(), "EVT2".into()]),
         tickers: Some(vec!["TKR1".into(), "TKR2".into(), "TKR3".into()]),
         ..Default::default()
@@ -1043,7 +1149,7 @@ fn get_markets_params_validates_timestamp_mutual_exclusion() {
     // min_updated_ts cannot combine with other filters
     let params = GetMarketsParams {
         min_updated_ts: Some(1000),
-        status: Some(MarketStatus::Open),
+        status: Some(MarketStatusQuery::Open),
         ..Default::default()
     };
     assert!(params.validate().is_err());

--- a/tests/rest_communications.rs
+++ b/tests/rest_communications.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use kalshi_fast::{
-    CreateQuoteRequest, CreateRFQRequest, GetMarketsParams, KalshiRestClient, MarketStatus,
+    CreateQuoteRequest, CreateRFQRequest, GetMarketsParams, KalshiRestClient, MarketStatusQuery,
 };
 use std::time::Duration;
 
@@ -20,7 +20,7 @@ async fn test_rfq_lifecycle() {
         client
             .get_markets(GetMarketsParams {
                 limit: Some(1),
-                status: Some(MarketStatus::Open),
+                status: Some(MarketStatusQuery::Open),
                 ..Default::default()
             })
             .await
@@ -88,7 +88,7 @@ async fn test_quote_lifecycle() {
         client
             .get_markets(GetMarketsParams {
                 limit: Some(1),
-                status: Some(MarketStatus::Open),
+                status: Some(MarketStatusQuery::Open),
                 ..Default::default()
             })
             .await

--- a/tests/rest_orders.rs
+++ b/tests/rest_orders.rs
@@ -5,7 +5,7 @@ mod common;
 use kalshi_fast::{
     AmendOrderRequest, BatchCancelOrdersRequest, BatchCreateOrdersRequest, BuySell,
     CancelOrderParams, CreateOrderRequest, GetMarketsParams, GetOrdersParams, KalshiRestClient,
-    MarketStatus, OrderType, YesNo,
+    MarketStatusQuery, OrderType, YesNo,
 };
 use std::time::Duration;
 
@@ -23,7 +23,7 @@ async fn test_order_lifecycle() {
         client
             .get_markets(GetMarketsParams {
                 limit: Some(1),
-                status: Some(MarketStatus::Open),
+                status: Some(MarketStatusQuery::Open),
                 ..Default::default()
             })
             .await
@@ -147,7 +147,7 @@ async fn test_batch_order_lifecycle() {
         client
             .get_markets(GetMarketsParams {
                 limit: Some(1),
-                status: Some(MarketStatus::Open),
+                status: Some(MarketStatusQuery::Open),
                 ..Default::default()
             })
             .await

--- a/tests/rest_public.rs
+++ b/tests/rest_public.rs
@@ -7,7 +7,7 @@ use kalshi_fast::{
     GetIncentiveProgramsParams, GetMarketCandlesticksParams, GetMarketsParams, GetMilestonesParams,
     GetMultivariateEventCollectionLookupHistoryParams, GetMultivariateEventCollectionsParams,
     GetMultivariateEventsParams, GetSeriesFeeChangesParams, GetSeriesListParams,
-    GetStructuredTargetsParams, GetTradesParams, KalshiRestClient, MarketStatus,
+    GetStructuredTargetsParams, GetTradesParams, KalshiRestClient, MarketStatusQuery,
 };
 
 #[tokio::test]
@@ -132,7 +132,7 @@ async fn test_get_markets() {
         client
             .get_markets(GetMarketsParams {
                 limit: Some(5),
-                status: Some(MarketStatus::Open),
+                status: Some(MarketStatusQuery::Open),
                 ..Default::default()
             })
             .await
@@ -153,7 +153,7 @@ async fn test_get_market_by_ticker() {
         client
             .get_markets(GetMarketsParams {
                 limit: Some(1),
-                status: Some(MarketStatus::Open),
+                status: Some(MarketStatusQuery::Open),
                 ..Default::default()
             })
             .await
@@ -187,7 +187,7 @@ async fn test_get_market_orderbook() {
         client
             .get_markets(GetMarketsParams {
                 limit: Some(1),
-                status: Some(MarketStatus::Open),
+                status: Some(MarketStatusQuery::Open),
                 ..Default::default()
             })
             .await
@@ -220,7 +220,7 @@ async fn test_get_trades() {
         client
             .get_markets(GetMarketsParams {
                 limit: Some(1),
-                status: Some(MarketStatus::Open),
+                status: Some(MarketStatusQuery::Open),
                 ..Default::default()
             })
             .await
@@ -598,7 +598,7 @@ async fn test_batch_get_market_candlesticks() {
         client
             .get_markets(GetMarketsParams {
                 limit: Some(1),
-                status: Some(MarketStatus::Open),
+                status: Some(MarketStatusQuery::Open),
                 ..Default::default()
             })
             .await
@@ -640,7 +640,7 @@ async fn test_get_market_candlesticks() {
         client
             .get_markets(GetMarketsParams {
                 limit: Some(1),
-                status: Some(MarketStatus::Open),
+                status: Some(MarketStatusQuery::Open),
                 ..Default::default()
             })
             .await
@@ -754,7 +754,7 @@ async fn test_get_markets_all() {
         client
             .get_markets_all(GetMarketsParams {
                 limit: Some(100),
-                status: Some(MarketStatus::Open),
+                status: Some(MarketStatusQuery::Open),
                 ..Default::default()
             })
             .await
@@ -776,7 +776,7 @@ async fn test_get_trades_all() {
         client
             .get_markets(GetMarketsParams {
                 limit: Some(1),
-                status: Some(MarketStatus::Open),
+                status: Some(MarketStatusQuery::Open),
                 ..Default::default()
             })
             .await

--- a/tests/ws_auth.rs
+++ b/tests/ws_auth.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use kalshi_fast::{
-    GetMarketsParams, KalshiRestClient, KalshiWsLowLevelClient, MarketStatus, WsChannel,
+    GetMarketsParams, KalshiRestClient, KalshiWsLowLevelClient, MarketStatusQuery, WsChannel,
     WsDataMessage, WsMessage, WsSubscriptionParams,
 };
 use std::time::Duration;
@@ -35,7 +35,7 @@ async fn test_ws_orderbook_delta_subscribe() {
         rest_client
             .get_markets(GetMarketsParams {
                 limit: Some(1),
-                status: Some(MarketStatus::Open),
+                status: Some(MarketStatusQuery::Open),
                 ..Default::default()
             })
             .await


### PR DESCRIPTION
## Summary
- clarify status typing by renaming query enum `MarketStatus` to `MarketStatusQuery`
- rename REST lifecycle enum `MarketState` to `MarketStatus`
- update `GetMarketsParams.status` and `Market.status` to the new status types
- add strict and best-effort conversions for lifecycle/query status mapping
- add `KalshiError::Parse` with context, human-readable reason, raw bytes, and optional serde source
- add public parse accessors: `parse_context()`, `parse_error_reason()`, and `parse_raw_bytes()`
- return structured parse errors from REST success-body decoding and WS envelope/message parsing paths
- update changelog notes under `0.3.0`

## Breaking
- removed old `MarketState` and old query `MarketStatus` names without aliases
- added a new `KalshiError` enum variant (`Parse`), so exhaustive `match` statements must handle it

## Testing
- `cargo test`
