### PR TITLE
[v0.4][2/n] refactor!: migrate REST + WS clients to V2 APIs and bump to 0.4.0

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -47,7 +47,7 @@ jobs:
             done
           }
 
-          retry 3 cargo test --features live-tests --test rest_public --verbose
-          retry 3 cargo test --features live-tests --test rest_auth --verbose
-          retry 3 cargo test --features live-tests --test ws_public --verbose
-          retry 3 cargo test --features live-tests --test ws_auth --verbose
+          retry 3 cargo test --features live-tests --test rest_public --verbose -- --test-threads=1
+          retry 3 cargo test --features live-tests --test rest_auth --verbose -- --test-threads=1
+          retry 3 cargo test --features live-tests --test ws_public --verbose -- --test-threads=1
+          retry 3 cargo test --features live-tests --test ws_auth --verbose -- --test-threads=1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,16 +15,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.x"
-    - name: Install Python deps
-      run: pip install pyyaml
-    - name: Check Spec Parity Artifacts
-      run: |
-        scripts/generate_spec_parity.py
-        git diff --exit-code -- docs/spec-parity.md docs/specs/kalshi/openapi-manifest.json docs/specs/kalshi/asyncapi-manifest.json
     - name: Fmt
       run: cargo fmt --all --check
     - name: Clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "kalshi-fast-rs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -729,7 +729,6 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "serde_yaml",
  "sha2",
  "thiserror 1.0.69",
  "tokio",
@@ -1360,19 +1359,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,12 +1752,6 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kalshi-fast-rs"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 description = "High-performance async Rust client for Kalshi prediction markets API with full WebSocket support"
 license = "MIT"
@@ -48,7 +48,6 @@ httpdate = "1"
 anyhow = "1"
 dotenvy = "0.15"
 chrono = "0.4"
-serde_yaml = "0.9"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ High-performance async Rust client for the [Kalshi](https://kalshi.com) Trade AP
 
 ## Highlights
 
-- REST parity with Kalshi Trade API `3.8.0` OpenAPI snapshot (`77/77` path+method operations)
-- WebSocket parity with current AsyncAPI snapshot, including `user_orders`
+- REST parity with the current Kalshi Trade API OpenAPI surface
+- WebSocket parity with the current AsyncAPI surface, including `user_orders`
 - Deterministic REST resilience: retries, exponential backoff+jitter, `429 Retry-After` support
 - Builder-based transport controls: timeout, connect timeout, headers, user-agent, proxy, custom `reqwest::Client`
 - Explicit WebSocket lifecycle controls: `close()` + configurable `shutdown_timeout(...)`
@@ -100,12 +100,9 @@ async fn main() -> anyhow::Result<()> {
 - `examples/list_open_markets.rs`
 - `examples/orderbook_stream.rs`
 
-## Spec Parity Artifacts
+## Spec Notes
 
-- OpenAPI snapshot: `docs/specs/kalshi/openapi.yaml`
-- AsyncAPI snapshot: `docs/specs/kalshi/asyncapi.yaml`
-- Parity report: `docs/spec-parity.md`
-- Regeneration script: `scripts/generate_spec_parity.py`
+- Notes on spec-to-crate distinctions: `docs/spec-parity.md`
 
 ## Environment Variables
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -87,7 +87,8 @@ Repo refresh automations should:
 1. Read `AGENTS.md`, this file, and the active `CHANGELOG.md` entry.
 2. Check the Kalshi source-of-truth docs: `llms.txt`, changelog RSS, OpenAPI, and AsyncAPI.
 3. Classify upstream changes as breaking or non-breaking.
-4. Refresh local snapshots and parity artifacts.
+4. Update `docs/spec-parity.md` when there is a spec-to-crate distinction
+   worth documenting.
 5. Remove or update stale deprecated endpoints, API shapes, fields, and tests.
 6. Propose the version bump using the rules above.
 7. Update `CHANGELOG.md`, README, and crate docs if the public contract or compatibility statement changed.

--- a/examples/lob_delta.rs
+++ b/examples/lob_delta.rs
@@ -2,8 +2,8 @@
 ///
 /// This channel is explicitly called out in the docs as being authenticated
 use kalshi_fast::{
-    KalshiAuth, KalshiEnvironment, KalshiWsClient, WsChannel, WsEvent, WsReconnectConfig,
-    WsSubscriptionParams,
+    KalshiAuth, KalshiEnvironment, KalshiWsClient, WsChannelV2, WsEvent, WsReconnectConfig,
+    WsSubscriptionParamsV2,
 };
 
 #[tokio::main]
@@ -18,15 +18,15 @@ async fn main() -> anyhow::Result<()> {
     let mut ws =
         KalshiWsClient::connect_authenticated(env, auth, WsReconnectConfig::default()).await?;
 
-    ws.subscribe(WsSubscriptionParams {
-        channels: vec![WsChannel::OrderbookDelta],
+    ws.subscribe_v2(WsSubscriptionParamsV2 {
+        channels: vec![WsChannelV2::OrderbookDelta],
         market_tickers: Some(vec!["SOME_MARKET_TICKER".to_string()]),
         ..Default::default()
     })
     .await?;
 
     loop {
-        match ws.next_event().await? {
+        match ws.next_event_v2().await? {
             WsEvent::Message(msg) => println!("{:?}", msg),
             WsEvent::Raw(_) => {}
             WsEvent::Reconnected { attempt } => println!("Reconnected (attempt {})", attempt),

--- a/examples/orderbook_stream.rs
+++ b/examples/orderbook_stream.rs
@@ -8,8 +8,8 @@
 /// Requires KALSHI_KEY_ID and KALSHI_PRIVATE_KEY_PATH env vars (or .env file)
 use kalshi_fast::{
     GetMarketsParams, KalshiAuth, KalshiEnvironment, KalshiRestClient, KalshiWsClient, Market,
-    MarketStatusQuery, MveFilter, WsDataMessage, WsEvent, WsMessage, WsReconnectConfig,
-    WsSubscriptionParams,
+    MarketStatusQuery, MveFilter, WsDataMessageV2, WsEvent, WsMessageV2, WsReconnectConfig,
+    WsSubscriptionParamsV2,
 };
 use std::time::Duration;
 use tokio::time::sleep;
@@ -118,8 +118,8 @@ async fn main() -> anyhow::Result<()> {
 
     // Step 4: Subscribe to orderbook deltas
     let sub_id = ws
-        .subscribe(WsSubscriptionParams {
-            channels: vec![kalshi_fast::WsChannel::OrderbookDelta],
+        .subscribe_v2(WsSubscriptionParamsV2 {
+            channels: vec![kalshi_fast::WsChannelV2::OrderbookDelta],
             market_tickers: Some(market_tickers),
             ..Default::default()
         })
@@ -129,9 +129,9 @@ async fn main() -> anyhow::Result<()> {
 
     // Step 5: Stream updates
     loop {
-        match ws.next_event().await? {
+        match ws.next_event_v2().await? {
             WsEvent::Message(msg) => match msg {
-                WsMessage::Data(WsDataMessage::OrderbookSnapshot { msg, seq, .. }) => {
+                WsMessageV2::Data(WsDataMessageV2::OrderbookSnapshot { msg, seq, .. }) => {
                     println!(
                         "[SNAPSHOT] {} | yes={} no={} | seq={:?}",
                         msg.market_ticker,
@@ -140,14 +140,14 @@ async fn main() -> anyhow::Result<()> {
                         seq
                     );
                 }
-                WsMessage::Data(WsDataMessage::OrderbookDelta { msg, seq, .. }) => {
+                WsMessageV2::Data(WsDataMessageV2::OrderbookDelta { msg, seq, .. }) => {
                     println!(
                         "[DELTA] {} | {}@{} {:+} | seq={:?}",
-                        msg.market_ticker, msg.side, msg.price, msg.delta, seq
+                        msg.market_ticker, msg.side, msg.price_dollars, msg.delta_fp, seq
                     );
                 }
-                WsMessage::Subscribed { sid, .. } => println!("[SUBSCRIBED] sid={:?}", sid),
-                WsMessage::Error { error, .. } => println!("[ERROR] {:?}", error),
+                WsMessageV2::Subscribed { sid, .. } => println!("[SUBSCRIBED] sid={:?}", sid),
+                WsMessageV2::Error { error, .. } => println!("[ERROR] {:?}", error),
                 other => println!("[OTHER] {:?}", other),
             },
             WsEvent::Raw(_) => {}

--- a/examples/public_ticker_stream.rs
+++ b/examples/public_ticker_stream.rs
@@ -1,6 +1,6 @@
 use kalshi_fast::{
-    KalshiAuth, KalshiEnvironment, KalshiWsClient, WsChannel, WsDataMessage, WsEvent, WsMessage,
-    WsReaderConfig, WsReconnectConfig, WsSubscriptionParams,
+    KalshiAuth, KalshiEnvironment, KalshiWsClient, WsChannelV2, WsDataMessageV2, WsEvent,
+    WsMessageV2, WsReaderConfig, WsReconnectConfig, WsSubscriptionParamsV2,
 };
 
 #[tokio::main]
@@ -16,21 +16,21 @@ async fn main() -> anyhow::Result<()> {
     let mut ws =
         KalshiWsClient::connect_authenticated(env, auth, WsReconnectConfig::default()).await?;
 
-    ws.subscribe(WsSubscriptionParams {
-        channels: vec![WsChannel::Ticker],
+    ws.subscribe_v2(WsSubscriptionParamsV2 {
+        channels: vec![WsChannelV2::Ticker],
         ..Default::default()
     })
     .await?;
 
-    let events = ws.start_reader(WsReaderConfig::default()).await?;
+    let events = ws.start_reader_v2(WsReaderConfig::default()).await?;
 
     while let Some(event) = events.next().await {
         match event {
             WsEvent::Message(msg) => match msg {
-                WsMessage::Data(WsDataMessage::Ticker { msg, .. }) => {
+                WsMessageV2::Data(WsDataMessageV2::Ticker { msg, .. }) => {
                     println!(
                         "type=ticker market={} price={}",
-                        msg.market_ticker, msg.price
+                        msg.market_ticker, msg.price_dollars
                     );
                 }
                 other => {

--- a/examples/raw_borrowed_stream.rs
+++ b/examples/raw_borrowed_stream.rs
@@ -1,22 +1,27 @@
 /// Example: consume raw WS events and parse a borrowed view
 use kalshi_fast::{
-    KalshiEnvironment, KalshiWsClient, WsChannel, WsDataMessageRef, WsEvent, WsMessageRef,
-    WsReaderConfig, WsReaderMode, WsReconnectConfig, WsSubscriptionParams,
+    KalshiAuth, KalshiEnvironment, KalshiWsClient, WsChannelV2, WsDataMessageRef, WsEvent,
+    WsMessageRef, WsReaderConfig, WsReaderMode, WsReconnectConfig, WsSubscriptionParamsV2,
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let env = KalshiEnvironment::demo();
-    let mut ws = KalshiWsClient::connect(env, WsReconnectConfig::default()).await?;
+    let auth = KalshiAuth::from_pem_file(
+        std::env::var("KALSHI_KEY_ID")?,
+        std::env::var("KALSHI_PRIVATE_KEY_PATH")?,
+    )?;
+    let mut ws =
+        KalshiWsClient::connect_authenticated(env, auth, WsReconnectConfig::default()).await?;
 
-    ws.subscribe(WsSubscriptionParams {
-        channels: vec![WsChannel::Ticker],
+    ws.subscribe_v2(WsSubscriptionParamsV2 {
+        channels: vec![WsChannelV2::Ticker],
         ..Default::default()
     })
     .await?;
 
     let events = ws
-        .start_reader(WsReaderConfig {
+        .start_reader_v2(WsReaderConfig {
             buffer_size: 1024,
             mode: WsReaderMode::Raw,
         })
@@ -29,7 +34,7 @@ async fn main() -> anyhow::Result<()> {
                 if let WsMessageRef::Data(WsDataMessageRef::Ticker { msg, .. }) = msg {
                     println!(
                         "type=ticker market={} price={}",
-                        msg.market_ticker, msg.price
+                        msg.market_ticker, msg.price_dollars
                     );
                 }
             }

--- a/examples/ws_user_orders.rs
+++ b/examples/ws_user_orders.rs
@@ -1,6 +1,7 @@
 use kalshi_fast::{
-    KalshiAuth, KalshiEnvironment, KalshiWsClient, WsChannel, WsDataMessage, WsEvent, WsMessage,
-    WsReconnectConfig, WsSubscriptionParams, WsUpdateAction, WsUpdateSubscriptionParams,
+    KalshiAuth, KalshiEnvironment, KalshiWsClient, WsChannelV2, WsDataMessageV2, WsEvent,
+    WsMessageV2, WsReconnectConfig, WsSubscriptionParamsV2, WsUpdateAction,
+    WsUpdateSubscriptionParamsV2,
 };
 
 #[tokio::main]
@@ -17,15 +18,15 @@ async fn main() -> anyhow::Result<()> {
     .await?;
 
     let sub_cmd_id = ws
-        .subscribe(WsSubscriptionParams {
-            channels: vec![WsChannel::UserOrders],
+        .subscribe_v2(WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::UserOrders],
             ..Default::default()
         })
         .await?;
 
-    while let Ok(event) = ws.next_event().await {
+    while let Ok(event) = ws.next_event_v2().await {
         match event {
-            WsEvent::Message(WsMessage::Subscribed {
+            WsEvent::Message(WsMessageV2::Subscribed {
                 id: Some(id),
                 sid: Some(subscription_id),
             }) if id == sub_cmd_id => {
@@ -33,7 +34,7 @@ async fn main() -> anyhow::Result<()> {
 
                 // Update action example (for channels supporting market filters).
                 let _ = ws
-                    .update_subscription(WsUpdateSubscriptionParams {
+                    .update_subscription_v2(WsUpdateSubscriptionParamsV2 {
                         action: WsUpdateAction::AddMarkets,
                         sid: Some(subscription_id),
                         sids: None,
@@ -42,10 +43,11 @@ async fn main() -> anyhow::Result<()> {
                         market_id: None,
                         market_ids: None,
                         send_initial_snapshot: None,
+                        skip_ticker_ack: None,
                     })
                     .await;
             }
-            WsEvent::Message(WsMessage::Data(WsDataMessage::UserOrder { msg, .. })) => {
+            WsEvent::Message(WsMessageV2::Data(WsDataMessageV2::UserOrder { msg, .. })) => {
                 println!(
                     "order={} ticker={} status={:?}",
                     msg.order_id, msg.ticker, msg.status

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 
 //! ## Features
 //!
-//! - **OpenAPI parity** — full REST operation coverage for the current docs snapshot
+//! - **OpenAPI parity** — full REST operation coverage for the current published docs
 //! - **AsyncAPI parity** — WebSocket commands, responses, and `user_orders`
 //! - **Pagination helpers** — page-level ([`CursorPager`]) and item-level (`stream_*`) iteration
 //! - **REST reliability controls** — retry/backoff/jitter with `429 Retry-After` support
@@ -48,8 +48,8 @@
 //!
 //! ```no_run
 //! use kalshi_fast::{
-//!     KalshiAuth, KalshiEnvironment, KalshiWsClient, WsChannel,
-//!     WsDataMessage, WsEvent, WsMessage, WsReconnectConfig, WsSubscriptionParams,
+//!     KalshiAuth, KalshiEnvironment, KalshiWsClient, WsChannelV2,
+//!     WsDataMessageV2, WsEvent, WsMessageV2, WsReconnectConfig, WsSubscriptionParamsV2,
 //! };
 //!
 //! # async fn run() -> Result<(), kalshi_fast::KalshiError> {
@@ -64,14 +64,14 @@
 //!     WsReconnectConfig::default(),
 //! ).await?;
 //!
-//! ws.subscribe(WsSubscriptionParams {
-//!     channels: vec![WsChannel::UserOrders],
+//! ws.subscribe_v2(WsSubscriptionParamsV2 {
+//!     channels: vec![WsChannelV2::UserOrders],
 //!     ..Default::default()
 //! }).await?;
 //!
 //! loop {
-//!     match ws.next_event().await? {
-//!         WsEvent::Message(WsMessage::Data(WsDataMessage::UserOrder { msg, .. })) => {
+//!     match ws.next_event_v2().await? {
+//!         WsEvent::Message(WsMessageV2::Data(WsDataMessageV2::UserOrder { msg, .. })) => {
 //!             println!("order={} status={:?}", msg.order_id, msg.status);
 //!         }
 //!         WsEvent::Reconnected { attempt } => println!("Reconnected (attempt {})", attempt),
@@ -167,6 +167,31 @@
 //! - **Deferred JSON parsing** — uses `serde_json::RawValue` to skip parsing unused fields
 //! - **Zero-copy message parsing** — binary WebSocket frames parsed with `from_slice`
 //! - **Split read/write streams** — no lock contention on WebSocket operations
+//!
+//! ## Reference Documents
+//!
+//! This crate follows Kalshi's published API descriptions. These documents are
+//! the canonical references when checking endpoint coverage, payload shapes, and
+//! recent platform changes:
+//!
+//! - `llms.txt`: <https://docs.kalshi.com/llms.txt>
+//!   - index of the current Kalshi documentation set
+//! - changelog RSS: <https://docs.kalshi.com/changelog/rss.xml>
+//!   - feed of recent documentation and contract updates
+//! - OpenAPI: <https://docs.kalshi.com/openapi.yaml>
+//!   - authoritative description of the REST API
+//! - AsyncAPI: <https://docs.kalshi.com/asyncapi.yaml>
+//!   - authoritative description of the WebSocket API
+//!
+//! Short notes on known spec-to-crate distinctions live in
+//! `docs/spec-parity.md`.
+//!
+//! Release history is documented in
+//! [`CHANGELOG.md`](https://github.com/PoorRican/kalshi-fast-rs/blob/main/CHANGELOG.md),
+//! and crate versioning policy is documented in
+//! [`VERSIONING.md`](https://github.com/PoorRican/kalshi-fast-rs/blob/main/VERSIONING.md).
+//! Together they describe both public Rust API changes and upstream Kalshi
+//! contract alignment.
 
 pub mod auth;
 pub mod env;

--- a/src/rest/client.rs
+++ b/src/rest/client.rs
@@ -912,6 +912,16 @@ impl KalshiRestClient {
         .await
     }
 
+    /// Get order books for multiple markets in one request.
+    pub async fn get_market_orderbooks(
+        &self,
+        params: GetMarketOrderbooksParams,
+    ) -> Result<GetMarketOrderbooksResponse, KalshiError> {
+        let path = Self::full_path("/markets/orderbooks");
+        self.send(Method::GET, &path, Some(&params), Option::<&()>::None, true)
+            .await
+    }
+
     // -----------------------------------------------
     // Trades
     // -----------------------------------------------
@@ -940,6 +950,14 @@ impl KalshiRestClient {
         let path = Self::full_path("/historical/fills");
         self.send(Method::GET, &path, Some(&params), Option::<&()>::None, true)
             .await
+    }
+
+    /// List historical fills. Requires auth.
+    pub async fn get_fills_historical(
+        &self,
+        params: GetHistoricalFillsParams,
+    ) -> Result<GetFillsResponse, KalshiError> {
+        self.get_historical_fills(params).await
     }
 
     /// List historical orders. Requires auth.
@@ -975,6 +993,22 @@ impl KalshiRestClient {
             Method::GET,
             &path,
             Option::<&()>::None,
+            Option::<&()>::None,
+            false,
+        )
+        .await
+    }
+
+    /// List historical trades.
+    pub async fn get_trades_historical(
+        &self,
+        params: GetTradesParams,
+    ) -> Result<GetTradesResponse, KalshiError> {
+        let path = Self::full_path("/historical/trades");
+        self.send(
+            Method::GET,
+            &path,
+            Some(&params),
             Option::<&()>::None,
             false,
         )
@@ -1509,6 +1543,37 @@ impl KalshiRestClient {
         .await
     }
 
+    pub async fn get_live_data_by_milestone(
+        &self,
+        milestone_id: &str,
+        params: GetLiveDataByMilestoneParams,
+    ) -> Result<GetLiveDataResponse, KalshiError> {
+        let path = Self::full_path(&format!("/live_data/milestone/{milestone_id}"));
+        self.send(
+            Method::GET,
+            &path,
+            Some(&params),
+            Option::<&()>::None,
+            false,
+        )
+        .await
+    }
+
+    pub async fn get_game_stats(
+        &self,
+        milestone_id: &str,
+    ) -> Result<GetGameStatsResponse, KalshiError> {
+        let path = Self::full_path(&format!("/live_data/milestone/{milestone_id}/game_stats"));
+        self.send(
+            Method::GET,
+            &path,
+            Option::<&()>::None,
+            Option::<&()>::None,
+            false,
+        )
+        .await
+    }
+
     pub async fn batch_get_market_candlesticks(
         &self,
         params: BatchGetMarketCandlesticksParams,
@@ -1642,6 +1707,15 @@ impl KalshiRestClient {
             false,
         )
         .await
+    }
+
+    pub async fn get_market_candlesticks_historical(
+        &self,
+        ticker: &str,
+        params: GetMarketCandlesticksHistoricalParams,
+    ) -> Result<GetMarketCandlesticksHistoricalResponse, KalshiError> {
+        self.get_historical_market_candlesticks(ticker, params)
+            .await
     }
 
     pub async fn get_market_candlesticks(

--- a/src/rest/types.rs
+++ b/src/rest/types.rs
@@ -5,7 +5,7 @@ use crate::types::{
     SelfTradePreventionType, TimeInForce, TradeTakerSide, YesNo, deserialize_null_as_empty_vec,
     deserialize_string_or_number, serialize_csv_opt,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
 use std::fmt;
 
@@ -217,6 +217,8 @@ pub struct EventData {
     pub strike_period: Option<String>,
     #[serde(default)]
     pub last_updated_ts: Option<String>,
+    #[serde(default)]
+    pub occurrence_datetime: Option<String>,
     #[serde(default)]
     pub description: Option<String>,
     #[serde(default)]
@@ -577,6 +579,8 @@ pub struct Market {
     #[serde(default)]
     pub expiration_value: Option<String>,
     #[serde(default)]
+    pub occurrence_datetime: Option<String>,
+    #[serde(default)]
     pub tick_size: Option<i64>,
     #[serde(default)]
     pub settlement_value: Option<i64>,
@@ -783,7 +787,7 @@ pub struct GetMarketResponse {
 
 /// --- Orderbook ---
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct Orderbook {
     /// Price levels: (price_cents, quantity)
     #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
@@ -799,7 +803,7 @@ pub struct Orderbook {
     pub no_dollars: Vec<(FixedPointDollars, i64)>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct OrderbookFp {
     /// Price levels: (price_dollars, quantity_fp)
     #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
@@ -815,11 +819,27 @@ pub struct GetMarketOrderbookParams {
     pub depth: Option<u32>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GetMarketOrderbookResponse {
     pub orderbook: Orderbook,
-    #[serde(default)]
-    pub orderbook_fp: Option<OrderbookFp>,
+    pub orderbook_fp: OrderbookFp,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct GetMarketOrderbooksParams {
+    pub tickers: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MarketOrderbookFp {
+    pub ticker: String,
+    pub orderbook_fp: OrderbookFp,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GetMarketOrderbooksResponse {
+    #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
+    pub orderbooks: Vec<MarketOrderbookFp>,
 }
 
 /// --- Trades ---
@@ -1438,10 +1458,10 @@ pub struct Fill {
     pub yes_price: Option<i64>,
     #[serde(default)]
     pub no_price: Option<i64>,
-    #[serde(default, alias = "yes_price_dollars")]
-    pub yes_price_fixed: Option<FixedPointDollars>,
-    #[serde(default, alias = "no_price_dollars")]
-    pub no_price_fixed: Option<FixedPointDollars>,
+    #[serde(default, alias = "yes_price_fixed")]
+    pub yes_price_dollars: Option<FixedPointDollars>,
+    #[serde(default, alias = "no_price_fixed")]
+    pub no_price_dollars: Option<FixedPointDollars>,
     #[serde(default)]
     pub side: Option<YesNo>,
     #[serde(default)]
@@ -1498,14 +1518,14 @@ pub struct Settlement {
     pub yes_count: Option<i64>,
     #[serde(default)]
     pub yes_count_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub yes_total_cost: Option<FixedPointDollars>,
+    #[serde(default, alias = "yes_total_cost")]
+    pub yes_total_cost_dollars: Option<FixedPointDollars>,
     #[serde(default)]
     pub no_count: Option<i64>,
     #[serde(default)]
     pub no_count_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub no_total_cost: Option<FixedPointDollars>,
+    #[serde(default, alias = "no_total_cost")]
+    pub no_total_cost_dollars: Option<FixedPointDollars>,
     #[serde(default)]
     pub revenue: Option<FixedPointDollars>,
     #[serde(default)]
@@ -1721,6 +1741,10 @@ pub struct Quote {
     pub rfq_creator_order_id: Option<String>,
     #[serde(default)]
     pub creator_order_id: Option<String>,
+    #[serde(default)]
+    pub yes_contracts_fp: Option<FixedPointCount>,
+    #[serde(default)]
+    pub no_contracts_fp: Option<FixedPointCount>,
     #[serde(default, flatten)]
     pub extra: Map<String, Value>,
 }
@@ -1986,6 +2010,12 @@ pub struct GetLiveDataResponse {
     pub live_data: LiveData,
 }
 
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct GetLiveDataByMilestoneParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_player_stats: Option<bool>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LiveData {
     #[serde(rename = "type")]
@@ -1993,6 +2023,14 @@ pub struct LiveData {
     #[serde(default)]
     pub details: Map<String, Value>,
     pub milestone_id: String,
+    #[serde(default, flatten)]
+    pub extra: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GetGameStatsResponse {
+    #[serde(default)]
+    pub pbp: Option<Value>,
     #[serde(default, flatten)]
     pub extra: Map<String, Value>,
 }
@@ -2069,9 +2107,11 @@ pub struct MarketCandlestick {
     pub yes_bid: BidAskDistribution,
     pub yes_ask: BidAskDistribution,
     pub price: PriceDistribution,
-    pub volume: i64,
+    #[serde(default)]
+    pub volume: Option<i64>,
     pub volume_fp: FixedPointCount,
-    pub open_interest: i64,
+    #[serde(default)]
+    pub open_interest: Option<i64>,
     pub open_interest_fp: FixedPointCount,
 }
 
@@ -2495,6 +2535,8 @@ pub struct GetHistoricalMarketsParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_ticker: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub series_ticker: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mve_filter: Option<MveFilter>,
 }
 
@@ -2697,4 +2739,86 @@ pub struct SubaccountNettingConfig {
 pub struct GetSubaccountNettingResponse {
     #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
     pub netting_configs: Vec<SubaccountNettingConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GetMarketOrderbookResponseWire {
+    #[serde(default)]
+    orderbook: Option<Orderbook>,
+    #[serde(default)]
+    orderbook_fp: Option<OrderbookFp>,
+}
+
+fn dollars_to_cents(value: &str) -> Option<i64> {
+    let (whole, frac) = value.split_once('.').unwrap_or((value, "0"));
+    let mut cents = frac.chars().take(2).collect::<String>();
+    while cents.len() < 2 {
+        cents.push('0');
+    }
+    Some(whole.parse::<i64>().ok()? * 100 + cents.parse::<i64>().ok()?)
+}
+
+fn fixed_point_count_to_i64(value: &str) -> Option<i64> {
+    value.split('.').next()?.parse::<i64>().ok()
+}
+
+fn synthesize_orderbook_from_fp(orderbook_fp: &OrderbookFp) -> Orderbook {
+    let convert = |levels: &[(FixedPointDollars, String)]| {
+        levels
+            .iter()
+            .filter_map(|(price, count)| {
+                Some((dollars_to_cents(price)?, fixed_point_count_to_i64(count)?))
+            })
+            .collect::<Vec<_>>()
+    };
+
+    Orderbook {
+        yes: convert(&orderbook_fp.yes_dollars),
+        no: convert(&orderbook_fp.no_dollars),
+        yes_dollars: orderbook_fp
+            .yes_dollars
+            .iter()
+            .filter_map(|(price, count)| Some((price.clone(), fixed_point_count_to_i64(count)?)))
+            .collect(),
+        no_dollars: orderbook_fp
+            .no_dollars
+            .iter()
+            .filter_map(|(price, count)| Some((price.clone(), fixed_point_count_to_i64(count)?)))
+            .collect(),
+    }
+}
+
+fn synthesize_orderbook_fp(orderbook: &Orderbook) -> OrderbookFp {
+    let convert = |levels: &[(FixedPointDollars, i64)]| {
+        levels
+            .iter()
+            .map(|(price, count)| (price.clone(), format!("{count}.00")))
+            .collect::<Vec<_>>()
+    };
+
+    OrderbookFp {
+        yes_dollars: convert(&orderbook.yes_dollars),
+        no_dollars: convert(&orderbook.no_dollars),
+    }
+}
+
+impl<'de> Deserialize<'de> for GetMarketOrderbookResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = GetMarketOrderbookResponseWire::deserialize(deserializer)?;
+        let orderbook_fp = wire
+            .orderbook_fp
+            .or_else(|| wire.orderbook.as_ref().map(synthesize_orderbook_fp))
+            .unwrap_or_default();
+        let orderbook = wire
+            .orderbook
+            .unwrap_or_else(|| synthesize_orderbook_from_fp(&orderbook_fp));
+
+        Ok(Self {
+            orderbook,
+            orderbook_fp,
+        })
+    }
 }

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -2,9 +2,9 @@ use crate::auth::KalshiAuth;
 use crate::env::{KalshiEnvironment, WS_PATH};
 use crate::error::KalshiError;
 use crate::ws::types::{
-    WsEnvelope, WsListSubscriptionsCmd, WsMessage, WsRawEvent, WsSubscribeCmd,
-    WsSubscriptionParams, WsUnsubscribeCmd, WsUnsubscribeParams, WsUpdateSubscriptionCmd,
-    WsUpdateSubscriptionParams, validate_subscription, validate_update,
+    WsEnvelope, WsListSubscriptionsCmd, WsMessageV2, WsRawEvent, WsSubscribeCmd,
+    WsSubscriptionParamsV2, WsUnsubscribeCmd, WsUnsubscribeParamsV2, WsUpdateSubscriptionCmd,
+    WsUpdateSubscriptionParamsV2, validate_subscription, validate_update,
 };
 
 use futures::{SinkExt, StreamExt};
@@ -109,7 +109,7 @@ impl Default for WsReaderConfig {
 #[derive(Debug)]
 pub enum WsEvent {
     /// A parsed WebSocket message (data, ack, error, etc.).
-    Message(WsMessage),
+    Message(WsMessageV2),
     Raw(WsRawEvent),
     /// Connection was lost and successfully re-established.
     ///
@@ -146,24 +146,24 @@ impl WsEventReceiver {
 
 #[derive(Default)]
 struct SubscriptionTracker {
-    pending: HashMap<u64, WsSubscriptionParams>,
-    active: HashMap<u64, WsSubscriptionParams>,
+    pending: HashMap<u64, WsSubscriptionParamsV2>,
+    active: HashMap<u64, WsSubscriptionParamsV2>,
 }
 
 impl SubscriptionTracker {
-    fn record_subscribe_cmd(&mut self, id: u64, params: WsSubscriptionParams) {
+    fn record_subscribe_cmd(&mut self, id: u64, params: WsSubscriptionParamsV2) {
         self.pending.insert(id, params);
     }
 
-    fn handle_message(&mut self, msg: &WsMessage) {
+    fn handle_message(&mut self, msg: &WsMessageV2) {
         match msg {
-            WsMessage::Subscribed {
+            WsMessageV2::Subscribed {
                 id: Some(id),
                 sid: Some(sid),
             } => {
                 self.handle_subscribed(Some(*id), Some(*sid));
             }
-            WsMessage::Unsubscribed { sid: Some(sid), .. } => {
+            WsMessageV2::Unsubscribed { sid: Some(sid), .. } => {
                 self.handle_unsubscribed(Some(*sid));
             }
             _ => {}
@@ -190,7 +190,7 @@ impl SubscriptionTracker {
         self.active.remove(&sid);
     }
 
-    fn apply_update(&mut self, update: &WsUpdateSubscriptionParams) {
+    fn apply_update(&mut self, update: &WsUpdateSubscriptionParamsV2) {
         use crate::ws::types::WsUpdateAction;
 
         let sid = match update.target_sid() {
@@ -241,10 +241,13 @@ impl SubscriptionTracker {
         if let Some(value) = update.send_initial_snapshot {
             params.send_initial_snapshot = Some(value);
         }
+        if let Some(value) = update.skip_ticker_ack {
+            params.skip_ticker_ack = Some(value);
+        }
     }
 
-    fn prepare_resubscribe(&mut self) -> Vec<WsSubscriptionParams> {
-        let mut params: Vec<WsSubscriptionParams> = self.active.values().cloned().collect();
+    fn prepare_resubscribe(&mut self) -> Vec<WsSubscriptionParamsV2> {
+        let mut params: Vec<WsSubscriptionParamsV2> = self.active.values().cloned().collect();
         params.extend(self.pending.values().cloned());
         self.active.clear();
         self.pending.clear();
@@ -273,19 +276,12 @@ impl KalshiWsLowLevelClient {
     // Connection
     // -----------------------------------------------
 
-    /// Connect without auth (public channels only).
-    pub async fn connect(env: KalshiEnvironment) -> Result<Self, KalshiError> {
-        let (ws_stream, _resp) = connect_async(&env.ws_url)
-            .await
-            .map_err(|e| KalshiError::Ws(e.to_string()))?;
-
-        let (write, read) = ws_stream.split();
-        Ok(Self {
-            write,
-            read,
-            next_id: 1,
-            authenticated: false,
-        })
+    /// Connect without auth.
+    ///
+    /// Kalshi now requires authentication at WebSocket handshake time for all
+    /// connections, including subscriptions to public channels.
+    pub async fn connect(_env: KalshiEnvironment) -> Result<Self, KalshiError> {
+        Err(KalshiError::AuthRequired("WebSocket connection"))
     }
 
     /// Connect with auth headers so you can subscribe to private channels.
@@ -375,9 +371,12 @@ impl KalshiWsLowLevelClient {
 
     /// Subscribe to one or more channels. Returns the command `id`.
     ///
-    /// Private channels (e.g. [`WsChannel::Fill`](crate::WsChannel::Fill))
+    /// Private channels (e.g. [`WsChannelV2::Fill`](crate::WsChannelV2::Fill))
     /// require an authenticated connection — see [`connect_authenticated`](Self::connect_authenticated).
-    pub async fn subscribe(&mut self, params: WsSubscriptionParams) -> Result<u64, KalshiError> {
+    pub async fn subscribe_v2(
+        &mut self,
+        params: WsSubscriptionParamsV2,
+    ) -> Result<u64, KalshiError> {
         let needs_auth = params.channels.iter().any(|c| c.is_private());
         if needs_auth && !self.authenticated {
             return Err(KalshiError::AuthRequired(
@@ -407,7 +406,10 @@ impl KalshiWsLowLevelClient {
 
     ///
     /// Unsubscribe from one or more subscriptions by SID. Returns the command `id`.
-    pub async fn unsubscribe(&mut self, params: WsUnsubscribeParams) -> Result<u64, KalshiError> {
+    pub async fn unsubscribe_v2(
+        &mut self,
+        params: WsUnsubscribeParamsV2,
+    ) -> Result<u64, KalshiError> {
         if params.sids.is_empty() {
             return Err(KalshiError::InvalidParams(
                 "unsubscribe: at least one sid is required".to_string(),
@@ -433,9 +435,9 @@ impl KalshiWsLowLevelClient {
     }
 
     /// Update an existing subscription (e.g. change market tickers). Returns the command `id`.
-    pub async fn update_subscription(
+    pub async fn update_subscription_v2(
         &mut self,
-        params: WsUpdateSubscriptionParams,
+        params: WsUpdateSubscriptionParamsV2,
     ) -> Result<u64, KalshiError> {
         validate_update(&params)?;
 
@@ -488,13 +490,13 @@ impl KalshiWsLowLevelClient {
             .map_err(|source| KalshiError::parse_json("websocket envelope", &bytes, source))
     }
 
-    /// Read the next message and parse it into a typed [`WsMessage`].
+    /// Read the next message and parse it into a typed [`WsMessageV2`].
     ///
     /// Equivalent to calling [`next_envelope`](Self::next_envelope) followed
     /// by [`WsEnvelope::into_message`].
-    pub async fn next_message(&mut self) -> Result<WsMessage, KalshiError> {
+    pub async fn next_message_v2(&mut self) -> Result<WsMessageV2, KalshiError> {
         let bytes = self.next_json_bytes().await?;
-        WsMessage::from_bytes(&bytes)
+        WsMessageV2::from_bytes(&bytes)
     }
 
     /// Gracefully close the underlying WebSocket.
@@ -514,25 +516,30 @@ impl KalshiWsLowLevelClient {
 ///
 /// ```no_run
 /// use kalshi_fast::{
-///     KalshiEnvironment, KalshiWsClient, WsChannel,
-///     WsDataMessage, WsEvent, WsMessage, WsReconnectConfig, WsSubscriptionParams,
+///     KalshiAuth, KalshiEnvironment, KalshiWsClient, WsChannelV2,
+///     WsDataMessageV2, WsEvent, WsMessageV2, WsReconnectConfig, WsSubscriptionParamsV2,
 /// };
 ///
 /// # async fn run() -> Result<(), kalshi_fast::KalshiError> {
-/// let mut ws = KalshiWsClient::connect(
+/// let auth = KalshiAuth::from_pem_file(
+///     std::env::var("KALSHI_KEY_ID").unwrap(),
+///     std::env::var("KALSHI_PRIVATE_KEY_PATH").unwrap(),
+/// )?;
+/// let mut ws = KalshiWsClient::connect_authenticated(
 ///     KalshiEnvironment::demo(),
+///     auth,
 ///     WsReconnectConfig::default(),
 /// ).await?;
 ///
-/// ws.subscribe(WsSubscriptionParams {
-///     channels: vec![WsChannel::Trade],
+/// ws.subscribe_v2(WsSubscriptionParamsV2 {
+///     channels: vec![WsChannelV2::Trade],
 ///     ..Default::default()
 /// }).await?;
 ///
 /// loop {
-///     match ws.next_event().await? {
-///         WsEvent::Message(WsMessage::Data(WsDataMessage::Trade { msg, .. })) => {
-///             println!("trade: {} @ {}", msg.ticker, msg.price.unwrap_or(0));
+///     match ws.next_event_v2().await? {
+///         WsEvent::Message(WsMessageV2::Data(WsDataMessageV2::Trade { msg, .. })) => {
+///             println!("trade: {} @ {}", msg.market_ticker, msg.yes_price_dollars);
 ///         }
 ///         WsEvent::Disconnected { .. } => break,
 ///         _ => {}
@@ -560,25 +567,15 @@ impl KalshiWsClient {
     // Connection
     // -----------------------------------------------
 
-    /// Connect without auth (public channels only).
+    /// Connect without auth.
+    ///
+    /// Kalshi now requires authentication at WebSocket handshake time for all
+    /// connections, including subscriptions to public channels.
     pub async fn connect(
-        env: KalshiEnvironment,
-        config: WsReconnectConfig,
+        _env: KalshiEnvironment,
+        _config: WsReconnectConfig,
     ) -> Result<Self, KalshiError> {
-        let client = KalshiWsLowLevelClient::connect(env.clone()).await?;
-        Ok(Self {
-            env,
-            auth: None,
-            client: Some(client),
-            config,
-            tracker: Arc::new(Mutex::new(SubscriptionTracker::default())),
-            reader: None,
-            outgoing: None,
-            shutdown: None,
-            reader_task: None,
-            reader_shutdown_timeout: Duration::from_secs(5),
-            next_id: 1,
-        })
+        Err(KalshiError::AuthRequired("WebSocket connection"))
     }
 
     /// Connect with auth headers for private channels.
@@ -630,7 +627,10 @@ impl KalshiWsClient {
     ///
     /// The subscription is tracked internally so it can be resubscribed
     /// automatically after a reconnect.
-    pub async fn subscribe(&mut self, params: WsSubscriptionParams) -> Result<u64, KalshiError> {
+    pub async fn subscribe_v2(
+        &mut self,
+        params: WsSubscriptionParamsV2,
+    ) -> Result<u64, KalshiError> {
         let needs_auth = params.channels.iter().any(|c| c.is_private());
         if needs_auth && self.auth.is_none() {
             return Err(KalshiError::AuthRequired(
@@ -660,7 +660,10 @@ impl KalshiWsClient {
     }
 
     /// Unsubscribe from one or more subscriptions by SID. Returns the command `id`.
-    pub async fn unsubscribe(&mut self, params: WsUnsubscribeParams) -> Result<u64, KalshiError> {
+    pub async fn unsubscribe_v2(
+        &mut self,
+        params: WsUnsubscribeParamsV2,
+    ) -> Result<u64, KalshiError> {
         if params.sids.is_empty() {
             return Err(KalshiError::InvalidParams(
                 "unsubscribe: at least one sid is required".to_string(),
@@ -688,9 +691,9 @@ impl KalshiWsClient {
     }
 
     /// Update an existing subscription (e.g. change market tickers). Returns the command `id`.
-    pub async fn update_subscription(
+    pub async fn update_subscription_v2(
         &mut self,
-        params: WsUpdateSubscriptionParams,
+        params: WsUpdateSubscriptionParamsV2,
     ) -> Result<u64, KalshiError> {
         validate_update(&params)?;
 
@@ -726,7 +729,7 @@ impl KalshiWsClient {
         Ok(id)
     }
 
-    pub async fn start_reader(
+    pub async fn start_reader_v2(
         &mut self,
         config: WsReaderConfig,
     ) -> Result<WsEventReceiver, KalshiError> {
@@ -835,7 +838,7 @@ impl KalshiWsClient {
     /// automatically attempts reconnection per [`WsReconnectConfig`],
     /// returning [`WsEvent::Reconnected`] on success or
     /// [`WsEvent::Disconnected`] when retries are exhausted.
-    pub async fn next_event(&mut self) -> Result<WsEvent, KalshiError> {
+    pub async fn next_event_v2(&mut self) -> Result<WsEvent, KalshiError> {
         if let Some(reader) = &self.reader {
             return reader
                 .next()
@@ -848,7 +851,7 @@ impl KalshiWsClient {
             .as_mut()
             .ok_or_else(|| KalshiError::Ws("websocket client not connected".to_string()))?;
 
-        match client.next_message().await {
+        match client.next_message_v2().await {
             Ok(msg) => {
                 let mut tracker = self.tracker.lock().await;
                 tracker.handle_message(&msg);
@@ -889,7 +892,7 @@ impl KalshiWsClient {
                 KalshiWsLowLevelClient::connect_authenticated(self.env.clone(), auth.clone())
                     .await?
             }
-            None => KalshiWsLowLevelClient::connect(self.env.clone()).await?,
+            None => return Err(KalshiError::AuthRequired("WebSocket connection")),
         };
         self.client = Some(new_client);
 
@@ -1054,7 +1057,7 @@ async fn handle_payload(
 ) -> Result<(), KalshiError> {
     match mode {
         WsReaderMode::Owned => {
-            let msg = WsMessage::from_bytes(&bytes)?;
+            let msg = WsMessageV2::from_bytes(&bytes)?;
             {
                 let mut tracker = tracker.lock().await;
                 tracker.handle_message(&msg);
@@ -1129,7 +1132,7 @@ async fn handle_reconnect(
                 Some(auth) => {
                     KalshiWsLowLevelClient::connect_authenticated(env.clone(), auth.clone()).await
                 }
-                None => KalshiWsLowLevelClient::connect(env.clone()).await,
+                None => Err(KalshiError::AuthRequired("WebSocket connection")),
             }
         };
         let reconnect = tokio::select! {
@@ -1150,7 +1153,7 @@ async fn handle_reconnect(
                     };
                     let mut resubscribe_err: Option<KalshiError> = None;
                     for p in params {
-                        match client.subscribe(p.clone()).await {
+                        match client.subscribe_v2(p.clone()).await {
                             Ok(id) => {
                                 let mut tracker = tracker.lock().await;
                                 tracker.record_subscribe_cmd(id, p);
@@ -1185,7 +1188,8 @@ async fn handle_reconnect(
 mod tests {
     use super::*;
     use crate::KalshiEnvironment;
-    use crate::ws::types::WsChannel;
+    use crate::auth::tests::load_test_auth;
+    use crate::ws::types::WsChannelV2;
     use serde_json::{Value, json};
     use tokio::net::TcpListener;
     use tokio::time::{Duration, Instant, timeout};
@@ -1193,29 +1197,55 @@ mod tests {
     use tokio_tungstenite::tungstenite::Message;
     use url::Url;
 
+    fn ticker_frame(market_ticker: &str, market_id: &str, sid: u64, seq: u64) -> String {
+        json!({
+            "type": "ticker",
+            "sid": sid,
+            "seq": seq,
+            "msg": {
+                "market_ticker": market_ticker,
+                "market_id": market_id,
+                "price_dollars": "0.01",
+                "yes_bid_dollars": "0.01",
+                "yes_ask_dollars": "0.02",
+                "yes_bid_size_fp": "1.00",
+                "yes_ask_size_fp": "2.00",
+                "last_trade_size_fp": "1.00",
+                "volume_fp": "0.00",
+                "open_interest_fp": "0.00",
+                "dollar_volume": 0,
+                "dollar_open_interest": 0,
+                "ts": 0,
+                "ts_ms": 0,
+                "time": "1970-01-01T00:00:00Z"
+            }
+        })
+        .to_string()
+    }
+
     #[test]
     fn private_channel_check() {
-        assert!(WsChannel::Fill.is_private());
-        assert!(WsChannel::OrderbookDelta.is_private());
-        assert!(WsChannel::MarketPositions.is_private());
-        assert!(WsChannel::Communications.is_private());
-        assert!(WsChannel::OrderGroupUpdates.is_private());
+        assert!(WsChannelV2::Fill.is_private());
+        assert!(WsChannelV2::OrderbookDelta.is_private());
+        assert!(WsChannelV2::MarketPositions.is_private());
+        assert!(WsChannelV2::Communications.is_private());
+        assert!(WsChannelV2::OrderGroupUpdates.is_private());
 
-        assert!(!WsChannel::Ticker.is_private());
-        assert!(!WsChannel::Trade.is_private());
-        assert!(!WsChannel::MarketLifecycleV2.is_private());
-        assert!(!WsChannel::Multivariate.is_private());
+        assert!(!WsChannelV2::Ticker.is_private());
+        assert!(!WsChannelV2::Trade.is_private());
+        assert!(!WsChannelV2::MarketLifecycleV2.is_private());
+        assert!(!WsChannelV2::Multivariate.is_private());
     }
 
     #[test]
     fn subscription_tracker_moves_pending_to_active() {
         let mut tracker = SubscriptionTracker::default();
-        let params = WsSubscriptionParams {
-            channels: vec![WsChannel::Ticker],
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::Ticker],
             ..Default::default()
         };
         tracker.record_subscribe_cmd(1, params.clone());
-        tracker.handle_message(&WsMessage::Subscribed {
+        tracker.handle_message(&WsMessageV2::Subscribed {
             id: Some(1),
             sid: Some(42),
         });
@@ -1228,12 +1258,12 @@ mod tests {
     #[test]
     fn subscription_tracker_prepare_resubscribe_clears_state() {
         let mut tracker = SubscriptionTracker::default();
-        let params = WsSubscriptionParams {
-            channels: vec![WsChannel::Ticker],
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::Ticker],
             ..Default::default()
         };
         tracker.record_subscribe_cmd(1, params.clone());
-        tracker.handle_message(&WsMessage::Subscribed {
+        tracker.handle_message(&WsMessageV2::Subscribed {
             id: Some(1),
             sid: Some(42),
         });
@@ -1249,14 +1279,14 @@ mod tests {
         use crate::ws::types::WsUpdateAction;
 
         let mut tracker = SubscriptionTracker::default();
-        let params = WsSubscriptionParams {
-            channels: vec![WsChannel::OrderbookDelta],
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::OrderbookDelta],
             market_tickers: Some(vec!["A".to_string()]),
             ..Default::default()
         };
         tracker.active.insert(10, params);
 
-        let update = WsUpdateSubscriptionParams {
+        let update = WsUpdateSubscriptionParamsV2 {
             action: WsUpdateAction::AddMarkets,
             sid: Some(10),
             sids: None,
@@ -1265,6 +1295,7 @@ mod tests {
             market_id: None,
             market_ids: None,
             send_initial_snapshot: Some(true),
+            skip_ticker_ack: Some(true),
         };
         tracker.apply_update(&update);
 
@@ -1284,6 +1315,7 @@ mod tests {
                 .contains(&"B".to_string())
         );
         assert_eq!(updated.send_initial_snapshot, Some(true));
+        assert_eq!(updated.skip_ticker_ack, Some(true));
     }
 
     #[tokio::test]
@@ -1294,26 +1326,26 @@ mod tests {
         let server = tokio::spawn(async move {
             let (stream, _) = listener.accept().await.expect("accept");
             let mut ws = accept_async(stream).await.expect("accept ws");
-            let msg1 = r#"{"type":"ticker","sid":1,"seq":1,"msg":{"market_ticker":"A","market_id":"1","price":1,"yes_bid":1,"yes_ask":2,"price_dollars":"0.01","yes_bid_dollars":"0.01","yes_ask_dollars":"0.02","volume":0,"volume_fp":"0","open_interest":0,"open_interest_fp":"0","dollar_volume":0,"dollar_open_interest":0,"ts":0}}"#;
-            let msg2 = r#"{"type":"ticker","sid":2,"seq":2,"msg":{"market_ticker":"B","market_id":"2","price":1,"yes_bid":1,"yes_ask":2,"price_dollars":"0.01","yes_bid_dollars":"0.01","yes_ask_dollars":"0.02","volume":0,"volume_fp":"0","open_interest":0,"open_interest_fp":"0","dollar_volume":0,"dollar_open_interest":0,"ts":0}}"#;
-            ws.send(Message::Text(msg1.to_string()))
+            ws.send(Message::Text(ticker_frame("A", "1", 1, 1)))
                 .await
                 .expect("send 1");
-            ws.send(Message::Text(msg2.to_string()))
+            ws.send(Message::Text(ticker_frame("B", "2", 2, 2)))
                 .await
                 .expect("send 2");
         });
 
+        let auth = load_test_auth();
         let env = KalshiEnvironment {
             rest_origin: Url::parse("http://127.0.0.1/").expect("url"),
             ws_url: format!("ws://{}", addr),
         };
-        let mut client = KalshiWsClient::connect(env, WsReconnectConfig::default())
-            .await
-            .expect("connect");
+        let mut client =
+            KalshiWsClient::connect_authenticated(env, auth, WsReconnectConfig::default())
+                .await
+                .expect("connect");
 
         let receiver = client
-            .start_reader(WsReaderConfig {
+            .start_reader_v2(WsReaderConfig {
                 buffer_size: 1,
                 mode: WsReaderMode::Owned,
             })
@@ -1343,20 +1375,19 @@ mod tests {
         let server = tokio::spawn(async move {
             let (stream, _) = listener.accept().await.expect("accept 1");
             let mut ws = accept_async(stream).await.expect("accept ws 1");
-            let msg1 = r#"{"type":"ticker","sid":1,"seq":1,"msg":{"market_ticker":"A","market_id":"1","price":1,"yes_bid":1,"yes_ask":2,"price_dollars":"0.01","yes_bid_dollars":"0.01","yes_ask_dollars":"0.02","volume":0,"volume_fp":"0","open_interest":0,"open_interest_fp":"0","dollar_volume":0,"dollar_open_interest":0,"ts":0}}"#;
-            ws.send(Message::Text(msg1.to_string()))
+            ws.send(Message::Text(ticker_frame("A", "1", 1, 1)))
                 .await
                 .expect("send 1");
             ws.close(None).await.expect("close 1");
 
             let (stream, _) = listener.accept().await.expect("accept 2");
             let mut ws = accept_async(stream).await.expect("accept ws 2");
-            let msg2 = r#"{"type":"ticker","sid":2,"seq":2,"msg":{"market_ticker":"B","market_id":"2","price":1,"yes_bid":1,"yes_ask":2,"price_dollars":"0.01","yes_bid_dollars":"0.01","yes_ask_dollars":"0.02","volume":0,"volume_fp":"0","open_interest":0,"open_interest_fp":"0","dollar_volume":0,"dollar_open_interest":0,"ts":0}}"#;
-            ws.send(Message::Text(msg2.to_string()))
+            ws.send(Message::Text(ticker_frame("B", "2", 2, 2)))
                 .await
                 .expect("send 2");
         });
 
+        let auth = load_test_auth();
         let env = KalshiEnvironment {
             rest_origin: Url::parse("http://127.0.0.1/").expect("url"),
             ws_url: format!("ws://{}", addr),
@@ -1368,10 +1399,12 @@ mod tests {
             jitter: 0.0,
             resubscribe: false,
         };
-        let mut client = KalshiWsClient::connect(env, config).await.expect("connect");
+        let mut client = KalshiWsClient::connect_authenticated(env, auth, config)
+            .await
+            .expect("connect");
 
         let receiver = client
-            .start_reader(WsReaderConfig {
+            .start_reader_v2(WsReaderConfig {
                 buffer_size: 4,
                 mode: WsReaderMode::Owned,
             })
@@ -1419,13 +1452,16 @@ mod tests {
             assert_eq!(payload["params"]["sids"], json!([7, 9]));
         });
 
+        let auth = load_test_auth();
         let env = KalshiEnvironment {
             rest_origin: Url::parse("http://127.0.0.1/").expect("url"),
             ws_url: format!("ws://{}", addr),
         };
-        let mut client = KalshiWsLowLevelClient::connect(env).await.expect("connect");
+        let mut client = KalshiWsLowLevelClient::connect_authenticated(env, auth)
+            .await
+            .expect("connect");
         client
-            .unsubscribe(WsUnsubscribeParams { sids: vec![7, 9] })
+            .unsubscribe_v2(WsUnsubscribeParamsV2 { sids: vec![7, 9] })
             .await
             .expect("unsubscribe");
 
@@ -1443,6 +1479,7 @@ mod tests {
             let _ = ws.close(None).await;
         });
 
+        let auth = load_test_auth();
         let env = KalshiEnvironment {
             rest_origin: Url::parse("http://127.0.0.1/").expect("url"),
             ws_url: format!("ws://{}", addr),
@@ -1454,10 +1491,12 @@ mod tests {
             jitter: 0.0,
             resubscribe: false,
         };
-        let mut client = KalshiWsClient::connect(env, config).await.expect("connect");
+        let mut client = KalshiWsClient::connect_authenticated(env, auth, config)
+            .await
+            .expect("connect");
 
         client
-            .start_reader(WsReaderConfig {
+            .start_reader_v2(WsReaderConfig {
                 buffer_size: 4,
                 mode: WsReaderMode::Owned,
             })

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -11,40 +11,46 @@
 //!
 //! | Channel | Auth | Description |
 //! |---------|------|-------------|
-//! | [`WsChannel::Ticker`] | No | Price / volume snapshots |
-//! | [`WsChannel::Trade`] | No | Public trades |
-//! | [`WsChannel::MarketLifecycleV2`] | No | Market open / close / settle events |
-//! | [`WsChannel::Multivariate`] | No | Multivariate market lookups |
-//! | [`WsChannel::OrderbookDelta`] | Yes | L2 order-book deltas (requires `market_tickers`) |
-//! | [`WsChannel::Fill`] | Yes | Your fills |
-//! | [`WsChannel::MarketPositions`] | Yes | Position changes |
-//! | [`WsChannel::Communications`] | Yes | RFQs and quotes |
-//! | [`WsChannel::OrderGroupUpdates`] | Yes | Order-group lifecycle |
-//! | [`WsChannel::UserOrders`] | Yes | User order lifecycle updates |
+//! | [`WsChannelV2::Ticker`] | No | Price / volume snapshots |
+//! | [`WsChannelV2::Trade`] | No | Public trades |
+//! | [`WsChannelV2::MarketLifecycleV2`] | No | Market open / close / settle events |
+//! | [`WsChannelV2::MultivariateMarketLifecycle`] | No | Multivariate market lifecycle events |
+//! | [`WsChannelV2::Multivariate`] | No | Multivariate market lookups |
+//! | [`WsChannelV2::OrderbookDelta`] | Yes | L2 order-book deltas (requires `market_tickers`) |
+//! | [`WsChannelV2::Fill`] | Yes | Your fills |
+//! | [`WsChannelV2::MarketPositions`] | Yes | Position changes |
+//! | [`WsChannelV2::Communications`] | Yes | RFQs and quotes |
+//! | [`WsChannelV2::OrderGroupUpdates`] | Yes | Order-group lifecycle |
+//! | [`WsChannelV2::UserOrders`] | Yes | User order lifecycle updates |
 //!
 //! # Quick Start — Public Ticker
 //!
 //! ```no_run
 //! use kalshi_fast::{
-//!     KalshiEnvironment, KalshiWsClient, WsChannel, WsDataMessage,
-//!     WsEvent, WsMessage, WsReconnectConfig, WsSubscriptionParams,
+//!     KalshiAuth, KalshiEnvironment, KalshiWsClient, WsChannelV2, WsDataMessageV2,
+//!     WsEvent, WsMessageV2, WsReconnectConfig, WsSubscriptionParamsV2,
 //! };
 //!
 //! # async fn run() -> Result<(), kalshi_fast::KalshiError> {
-//! let mut ws = KalshiWsClient::connect(
+//! let auth = KalshiAuth::from_pem_file(
+//!     std::env::var("KALSHI_KEY_ID").unwrap(),
+//!     std::env::var("KALSHI_PRIVATE_KEY_PATH").unwrap(),
+//! )?;
+//! let mut ws = KalshiWsClient::connect_authenticated(
 //!     KalshiEnvironment::demo(),
+//!     auth,
 //!     WsReconnectConfig::default(),
 //! ).await?;
 //!
-//! ws.subscribe(WsSubscriptionParams {
-//!     channels: vec![WsChannel::Ticker],
+//! ws.subscribe_v2(WsSubscriptionParamsV2 {
+//!     channels: vec![WsChannelV2::Ticker],
 //!     ..Default::default()
 //! }).await?;
 //!
 //! loop {
-//!     match ws.next_event().await? {
-//!         WsEvent::Message(WsMessage::Data(WsDataMessage::Ticker { msg, .. })) => {
-//!             println!("{}: {}", msg.market_ticker, msg.price);
+//!     match ws.next_event_v2().await? {
+//!         WsEvent::Message(WsMessageV2::Data(WsDataMessageV2::Ticker { msg, .. })) => {
+//!             println!("{}: {}", msg.market_ticker, msg.price_dollars);
 //!         }
 //!         WsEvent::Reconnected { attempt } => println!("Reconnected (attempt {attempt})"),
 //!         WsEvent::Disconnected { .. } => break,
@@ -57,12 +63,13 @@
 //!
 //! # Authenticated — Order-Book Deltas
 //!
-//! Private channels require [`KalshiWsClient::connect_authenticated`]:
+//! Kalshi requires [`KalshiWsClient::connect_authenticated`] for every WebSocket
+//! connection, including public channels:
 //!
 //! ```no_run
 //! use kalshi_fast::{
-//!     KalshiAuth, KalshiEnvironment, KalshiWsClient, WsChannel,
-//!     WsDataMessage, WsEvent, WsMessage, WsReconnectConfig, WsSubscriptionParams,
+//!     KalshiAuth, KalshiEnvironment, KalshiWsClient, WsChannelV2,
+//!     WsDataMessageV2, WsEvent, WsMessageV2, WsReconnectConfig, WsSubscriptionParamsV2,
 //! };
 //!
 //! # async fn run() -> Result<(), kalshi_fast::KalshiError> {
@@ -77,16 +84,16 @@
 //!     WsReconnectConfig::default(),
 //! ).await?;
 //!
-//! ws.subscribe(WsSubscriptionParams {
-//!     channels: vec![WsChannel::OrderbookDelta],
+//! ws.subscribe_v2(WsSubscriptionParamsV2 {
+//!     channels: vec![WsChannelV2::OrderbookDelta],
 //!     market_tickers: Some(vec!["SOME-MARKET".into()]),
 //!     ..Default::default()
 //! }).await?;
 //!
 //! loop {
-//!     match ws.next_event().await? {
-//!         WsEvent::Message(WsMessage::Data(WsDataMessage::OrderbookDelta { msg, .. })) => {
-//!             println!("{} {} delta={}", msg.market_ticker, msg.side, msg.delta);
+//!     match ws.next_event_v2().await? {
+//!         WsEvent::Message(WsMessageV2::Data(WsDataMessageV2::OrderbookDelta { msg, .. })) => {
+//!             println!("{} {} delta={}", msg.market_ticker, msg.side, msg.delta_fp);
 //!         }
 //!         WsEvent::Disconnected { .. } => break,
 //!         _ => {}
@@ -99,10 +106,10 @@
 //! # Message Flow
 //!
 //! ```text
-//! next_event() → WsEvent
-//!                 ├─ Message(WsMessage)
-//!                 │    ├─ Data(WsDataMessage::Ticker { .. })
-//!                 │    ├─ Data(WsDataMessage::Fill { .. })
+//! next_event_v2() → WsEvent
+//!                 ├─ Message(WsMessageV2)
+//!                 │    ├─ Data(WsDataMessageV2::Ticker { .. })
+//!                 │    ├─ Data(WsDataMessageV2::Fill { .. })
 //!                 │    ├─ Subscribed / Unsubscribed / Ok
 //!                 │    ├─ Error { .. }
 //!                 │    └─ Unknown { .. }
@@ -118,7 +125,7 @@
 //! emits [`WsEvent::Disconnected`]. Configure via [`WsReconnectConfig`].
 //!
 //! **Note:** Sequence resync is not automatic; callers must handle any gaps
-//! using the `seq` field on [`WsDataMessage`] variants.
+//! using the `seq` field on [`WsDataMessageV2`] variants.
 
 mod client;
 pub mod types;

--- a/src/ws/types.rs
+++ b/src/ws/types.rs
@@ -16,11 +16,12 @@ use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum WsChannel {
+pub enum WsChannelV2 {
     // Public (no auth required)
     Ticker,
     Trade,
     MarketLifecycleV2,
+    MultivariateMarketLifecycle,
     Multivariate,
 
     // Private (auth required)
@@ -32,36 +33,37 @@ pub enum WsChannel {
     UserOrders,
 }
 
-impl WsChannel {
+impl WsChannelV2 {
     pub fn as_str(self) -> &'static str {
         match self {
-            WsChannel::Ticker => "ticker",
-            WsChannel::Trade => "trade",
-            WsChannel::MarketLifecycleV2 => "market_lifecycle_v2",
-            WsChannel::Multivariate => "multivariate",
-            WsChannel::OrderbookDelta => "orderbook_delta",
-            WsChannel::Fill => "fill",
-            WsChannel::MarketPositions => "market_positions",
-            WsChannel::Communications => "communications",
-            WsChannel::OrderGroupUpdates => "order_group_updates",
-            WsChannel::UserOrders => "user_orders",
+            WsChannelV2::Ticker => "ticker",
+            WsChannelV2::Trade => "trade",
+            WsChannelV2::MarketLifecycleV2 => "market_lifecycle_v2",
+            WsChannelV2::MultivariateMarketLifecycle => "multivariate_market_lifecycle",
+            WsChannelV2::Multivariate => "multivariate",
+            WsChannelV2::OrderbookDelta => "orderbook_delta",
+            WsChannelV2::Fill => "fill",
+            WsChannelV2::MarketPositions => "market_positions",
+            WsChannelV2::Communications => "communications",
+            WsChannelV2::OrderGroupUpdates => "order_group_updates",
+            WsChannelV2::UserOrders => "user_orders",
         }
     }
 
     pub fn is_private(self) -> bool {
         matches!(
             self,
-            WsChannel::OrderbookDelta
-                | WsChannel::Fill
-                | WsChannel::MarketPositions
-                | WsChannel::Communications
-                | WsChannel::OrderGroupUpdates
-                | WsChannel::UserOrders
+            WsChannelV2::OrderbookDelta
+                | WsChannelV2::Fill
+                | WsChannelV2::MarketPositions
+                | WsChannelV2::Communications
+                | WsChannelV2::OrderGroupUpdates
+                | WsChannelV2::UserOrders
         )
     }
 }
 
-impl fmt::Display for WsChannel {
+impl fmt::Display for WsChannelV2 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
@@ -79,8 +81,9 @@ pub enum WsMsgType {
     OrderbookSnapshot,
     OrderbookDelta,
     Fill,
-    MarketPositions,
+    MarketPosition,
     MarketLifecycleV2,
+    MultivariateMarketLifecycle,
     EventLifecycle,
     Multivariate,
     MultivariateLookup,
@@ -108,8 +111,9 @@ impl WsMsgType {
             WsMsgType::OrderbookSnapshot => "orderbook_snapshot",
             WsMsgType::OrderbookDelta => "orderbook_delta",
             WsMsgType::Fill => "fill",
-            WsMsgType::MarketPositions => "market_positions",
+            WsMsgType::MarketPosition => "market_position",
             WsMsgType::MarketLifecycleV2 => "market_lifecycle_v2",
+            WsMsgType::MultivariateMarketLifecycle => "multivariate_market_lifecycle",
             WsMsgType::EventLifecycle => "event_lifecycle",
             WsMsgType::Multivariate => "multivariate",
             WsMsgType::MultivariateLookup => "multivariate_lookup",
@@ -137,8 +141,9 @@ impl WsMsgType {
             "orderbook_snapshot" => WsMsgType::OrderbookSnapshot,
             "orderbook_delta" => WsMsgType::OrderbookDelta,
             "fill" => WsMsgType::Fill,
-            "market_positions" => WsMsgType::MarketPositions,
+            "market_position" | "market_positions" => WsMsgType::MarketPosition,
             "market_lifecycle_v2" => WsMsgType::MarketLifecycleV2,
+            "multivariate_market_lifecycle" => WsMsgType::MultivariateMarketLifecycle,
             "event_lifecycle" | "event_lifecycle_v2" => WsMsgType::EventLifecycle,
             "multivariate" => WsMsgType::Multivariate,
             "multivariate_lookup" => WsMsgType::MultivariateLookup,
@@ -166,8 +171,9 @@ impl WsMsgType {
             "orderbook_snapshot" => WsMsgType::OrderbookSnapshot,
             "orderbook_delta" => WsMsgType::OrderbookDelta,
             "fill" => WsMsgType::Fill,
-            "market_positions" => WsMsgType::MarketPositions,
+            "market_position" | "market_positions" => WsMsgType::MarketPosition,
             "market_lifecycle_v2" => WsMsgType::MarketLifecycleV2,
+            "multivariate_market_lifecycle" => WsMsgType::MultivariateMarketLifecycle,
             "event_lifecycle" | "event_lifecycle_v2" => WsMsgType::EventLifecycle,
             "multivariate" => WsMsgType::Multivariate,
             "multivariate_lookup" => WsMsgType::MultivariateLookup,
@@ -231,8 +237,8 @@ impl<'de> Deserialize<'de> for WsMsgType {
 
 /// Subscription parameters for WebSocket channels.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct WsSubscriptionParams {
-    pub channels: Vec<WsChannel>,
+pub struct WsSubscriptionParamsV2 {
+    pub channels: Vec<WsChannelV2>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub market_ticker: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -253,7 +259,7 @@ pub struct WsSubscriptionParams {
     pub shard_key: Option<u32>,
 }
 
-impl WsSubscriptionParams {
+impl WsSubscriptionParamsV2 {
     /// Collect all market tickers from both singular and plural fields.
     pub fn all_market_tickers(&self) -> Vec<&str> {
         let mut out = Vec::new();
@@ -283,9 +289,9 @@ impl WsSubscriptionParams {
 pub struct WsSubscriptionInfo {
     pub sid: u64,
     #[serde(default)]
-    pub channels: Vec<WsChannel>,
+    pub channels: Vec<WsChannelV2>,
     #[serde(default)]
-    pub channel: Option<WsChannel>,
+    pub channel: Option<WsChannelV2>,
     #[serde(default)]
     pub market_tickers: Option<Vec<String>>,
     #[serde(default)]
@@ -294,6 +300,8 @@ pub struct WsSubscriptionInfo {
     pub event_tickers: Option<Vec<String>>,
     #[serde(default)]
     pub send_initial_snapshot: Option<bool>,
+    #[serde(default)]
+    pub skip_ticker_ack: Option<bool>,
     #[serde(default)]
     pub shard_factor: Option<u32>,
     #[serde(default)]
@@ -305,42 +313,51 @@ pub struct WsSubscriptionInfo {
 pub struct WsTicker {
     pub market_ticker: String,
     pub market_id: String,
+    #[serde(default)]
     pub price: i64,
+    #[serde(default)]
     pub yes_bid: i64,
+    #[serde(default)]
     pub yes_ask: i64,
     pub price_dollars: String,
     pub yes_bid_dollars: String,
     pub yes_ask_dollars: String,
+    pub yes_bid_size_fp: String,
+    pub yes_ask_size_fp: String,
+    pub last_trade_size_fp: String,
+    #[serde(default)]
     pub volume: i64,
     pub volume_fp: String,
+    #[serde(default)]
     pub open_interest: i64,
     pub open_interest_fp: String,
     pub dollar_volume: i64,
     pub dollar_open_interest: i64,
     pub ts: i64,
+    pub ts_ms: i64,
+    pub time: String,
 }
 
 /// Trade channel message (type: "trade")
 #[derive(Debug, Clone, Deserialize)]
 pub struct WsTrade {
     pub trade_id: String,
-    pub ticker: String,
+    #[serde(alias = "ticker")]
+    pub market_ticker: String,
     #[serde(default)]
     pub price: Option<i64>,
     #[serde(default)]
     pub count: Option<i64>,
-    #[serde(default)]
-    pub count_fp: Option<String>,
+    pub count_fp: String,
     #[serde(default)]
     pub yes_price: Option<i64>,
     #[serde(default)]
     pub no_price: Option<i64>,
-    #[serde(default)]
-    pub yes_price_dollars: Option<String>,
-    #[serde(default)]
-    pub no_price_dollars: Option<String>,
-    #[serde(default)]
-    pub taker_side: Option<TradeTakerSide>,
+    pub yes_price_dollars: String,
+    pub no_price_dollars: String,
+    pub taker_side: TradeTakerSide,
+    pub ts: i64,
+    pub ts_ms: i64,
     #[serde(default)]
     pub created_time: Option<String>,
 }
@@ -375,8 +392,10 @@ pub struct WsOrderbookSnapshot {
 pub struct WsOrderbookDelta {
     pub market_ticker: String,
     pub market_id: String,
+    #[serde(default)]
     pub price: i64,
     pub price_dollars: String,
+    #[serde(default)]
     pub delta: i64,
     pub delta_fp: String,
     pub side: YesNo,
@@ -386,36 +405,43 @@ pub struct WsOrderbookDelta {
     pub subaccount: Option<i64>,
     #[serde(default)]
     pub ts: Option<String>,
+    #[serde(default)]
+    pub ts_ms: Option<i64>,
 }
 
 /// Fill channel message (type: "fill")
 #[derive(Debug, Clone, Deserialize)]
 pub struct WsFill {
-    pub fill_id: String,
     pub trade_id: String,
     pub order_id: String,
     #[serde(default)]
     pub client_order_id: Option<String>,
-    pub ticker: String,
+    #[serde(alias = "ticker")]
     pub market_ticker: String,
     pub side: YesNo,
     pub action: BuySell,
+    #[serde(default)]
     pub count: i64,
     pub count_fp: String,
+    #[serde(default)]
     pub yes_price: i64,
+    #[serde(default)]
     pub no_price: i64,
-    #[serde(alias = "yes_price_dollars")]
-    pub yes_price_fixed: String,
-    #[serde(alias = "no_price_dollars")]
-    pub no_price_fixed: String,
+    #[serde(alias = "yes_price_fixed")]
+    pub yes_price_dollars: String,
+    #[serde(default, alias = "no_price_fixed")]
+    pub no_price_dollars: Option<String>,
     pub is_taker: bool,
     pub fee_cost: String,
+    pub ts: i64,
+    pub ts_ms: i64,
+    pub post_position_fp: String,
+    pub purchased_side: YesNo,
     #[serde(default)]
     pub created_time: Option<String>,
     #[serde(default)]
-    pub subaccount_number: Option<i64>,
-    #[serde(default)]
-    pub ts: Option<i64>,
+    #[serde(alias = "subaccount_number")]
+    pub subaccount: Option<i64>,
 }
 
 /// Market lifecycle message (type: "market_lifecycle_v2")
@@ -429,6 +455,20 @@ pub struct WsMarketLifecycleV2 {
     #[serde(default)]
     pub close_ts: Option<i64>,
     #[serde(default)]
+    pub result: Option<String>,
+    #[serde(default)]
+    pub determination_ts: Option<i64>,
+    #[serde(default)]
+    pub settlement_value: Option<String>,
+    #[serde(default)]
+    pub settled_ts: Option<i64>,
+    #[serde(default)]
+    pub is_deactivated: Option<bool>,
+    #[serde(default)]
+    pub fractional_trading_enabled: Option<bool>,
+    #[serde(default)]
+    pub price_level_structure: Option<String>,
+    #[serde(default)]
     pub additional_metadata: Option<WsMarketLifecycleAdditionalMetadata>,
 }
 
@@ -441,6 +481,8 @@ pub enum WsMarketLifecycleEventType {
     CloseDateUpdated,
     Determined,
     Settled,
+    FractionalTradingUpdated,
+    PriceLevelStructureUpdated,
     #[serde(other)]
     Unknown,
 }
@@ -468,7 +510,9 @@ pub struct WsMarketLifecycleAdditionalMetadata {
     #[serde(default)]
     pub strike_type: Option<String>,
     #[serde(default)]
-    pub floor_strike: Option<i64>,
+    pub floor_strike: Option<f64>,
+    #[serde(default)]
+    pub cap_strike: Option<f64>,
     #[serde(default)]
     pub custom_strike: Option<BTreeMap<String, String>>,
     #[serde(default, flatten)]
@@ -488,6 +532,10 @@ pub struct WsEventLifecycle {
     #[serde(default)]
     pub series_ticker: Option<String>,
     #[serde(default)]
+    pub strike_date: Option<i64>,
+    #[serde(default)]
+    pub strike_period: Option<String>,
+    #[serde(default)]
     pub additional_metadata: Option<WsEventLifecycleAdditionalMetadata>,
 }
 
@@ -499,13 +547,19 @@ pub struct WsEventLifecycleAdditionalMetadata {
     pub extra: Map<String, Value>,
 }
 
-/// Market positions message (type: "market_positions")
+/// Market position message (type: "market_position")
 #[derive(Debug, Clone, Deserialize)]
-pub struct WsMarketPositions {
+pub struct WsMarketPosition {
+    pub user_id: String,
+    pub market_ticker: String,
+    pub position_fp: FixedPointCount,
+    pub position_cost_dollars: FixedPointDollars,
+    pub realized_pnl_dollars: FixedPointDollars,
+    pub fees_paid_dollars: FixedPointDollars,
+    pub position_fee_cost_dollars: FixedPointDollars,
+    pub volume_fp: FixedPointCount,
     #[serde(default)]
-    pub market_positions: Vec<MarketPosition>,
-    #[serde(default)]
-    pub event_positions: Vec<EventPosition>,
+    pub subaccount: Option<u32>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -556,6 +610,8 @@ pub struct WsUserOrder {
     #[serde(default)]
     pub side: Option<YesNo>,
     #[serde(default)]
+    pub is_yes: Option<bool>,
+    #[serde(default)]
     pub yes_price_dollars: Option<FixedPointDollars>,
     #[serde(default)]
     pub fill_count_fp: Option<FixedPointCount>,
@@ -580,9 +636,15 @@ pub struct WsUserOrder {
     #[serde(default)]
     pub created_time: Option<String>,
     #[serde(default)]
+    pub created_ts_ms: Option<i64>,
+    #[serde(default)]
     pub last_update_time: Option<String>,
     #[serde(default)]
+    pub last_updated_ts_ms: Option<i64>,
+    #[serde(default)]
     pub expiration_time: Option<String>,
+    #[serde(default)]
+    pub expiration_ts_ms: Option<i64>,
     #[serde(default)]
     pub subaccount_number: Option<u32>,
 }
@@ -812,9 +874,9 @@ impl<'a> EventPositionRef<'a> {
 pub struct WsSubscriptionInfoRef<'a> {
     pub sid: u64,
     #[serde(default)]
-    pub channels: Vec<WsChannel>,
+    pub channels: Vec<WsChannelV2>,
     #[serde(default)]
-    pub channel: Option<WsChannel>,
+    pub channel: Option<WsChannelV2>,
     #[serde(default, borrow)]
     pub market_tickers: Option<Vec<Cow<'a, str>>>,
     #[serde(default, borrow)]
@@ -823,6 +885,8 @@ pub struct WsSubscriptionInfoRef<'a> {
     pub event_tickers: Option<Vec<Cow<'a, str>>>,
     #[serde(default)]
     pub send_initial_snapshot: Option<bool>,
+    #[serde(default)]
+    pub skip_ticker_ack: Option<bool>,
     #[serde(default)]
     pub shard_factor: Option<u32>,
     #[serde(default, borrow)]
@@ -845,6 +909,7 @@ impl<'a> WsSubscriptionInfoRef<'a> {
                 .event_tickers
                 .map(|v| v.into_iter().map(Cow::into_owned).collect()),
             send_initial_snapshot: self.send_initial_snapshot,
+            skip_ticker_ack: self.skip_ticker_ack,
             shard_factor: self.shard_factor,
             shard_key: self.shard_key.map(Cow::into_owned),
         }
@@ -858,8 +923,11 @@ pub struct WsTickerRef<'a> {
     pub market_ticker: Cow<'a, str>,
     #[serde(borrow)]
     pub market_id: Cow<'a, str>,
+    #[serde(default)]
     pub price: i64,
+    #[serde(default)]
     pub yes_bid: i64,
+    #[serde(default)]
     pub yes_ask: i64,
     #[serde(borrow)]
     pub price_dollars: Cow<'a, str>,
@@ -867,15 +935,26 @@ pub struct WsTickerRef<'a> {
     pub yes_bid_dollars: Cow<'a, str>,
     #[serde(borrow)]
     pub yes_ask_dollars: Cow<'a, str>,
+    #[serde(borrow)]
+    pub yes_bid_size_fp: Cow<'a, str>,
+    #[serde(borrow)]
+    pub yes_ask_size_fp: Cow<'a, str>,
+    #[serde(borrow)]
+    pub last_trade_size_fp: Cow<'a, str>,
+    #[serde(default)]
     pub volume: i64,
     #[serde(borrow)]
     pub volume_fp: Cow<'a, str>,
+    #[serde(default)]
     pub open_interest: i64,
     #[serde(borrow)]
     pub open_interest_fp: Cow<'a, str>,
     pub dollar_volume: i64,
     pub dollar_open_interest: i64,
     pub ts: i64,
+    pub ts_ms: i64,
+    #[serde(borrow)]
+    pub time: Cow<'a, str>,
 }
 
 impl<'a> WsTickerRef<'a> {
@@ -889,6 +968,9 @@ impl<'a> WsTickerRef<'a> {
             price_dollars: self.price_dollars.into_owned(),
             yes_bid_dollars: self.yes_bid_dollars.into_owned(),
             yes_ask_dollars: self.yes_ask_dollars.into_owned(),
+            yes_bid_size_fp: self.yes_bid_size_fp.into_owned(),
+            yes_ask_size_fp: self.yes_ask_size_fp.into_owned(),
+            last_trade_size_fp: self.last_trade_size_fp.into_owned(),
             volume: self.volume,
             volume_fp: self.volume_fp.into_owned(),
             open_interest: self.open_interest,
@@ -896,6 +978,8 @@ impl<'a> WsTickerRef<'a> {
             dollar_volume: self.dollar_volume,
             dollar_open_interest: self.dollar_open_interest,
             ts: self.ts,
+            ts_ms: self.ts_ms,
+            time: self.time.into_owned(),
         }
     }
 }
@@ -905,24 +989,25 @@ impl<'a> WsTickerRef<'a> {
 pub struct WsTradeRef<'a> {
     #[serde(borrow)]
     pub trade_id: Cow<'a, str>,
-    #[serde(borrow)]
-    pub ticker: Cow<'a, str>,
+    #[serde(alias = "ticker", borrow)]
+    pub market_ticker: Cow<'a, str>,
     #[serde(default)]
     pub price: Option<i64>,
     #[serde(default)]
     pub count: Option<i64>,
-    #[serde(default, borrow)]
-    pub count_fp: Option<Cow<'a, str>>,
+    #[serde(borrow)]
+    pub count_fp: Cow<'a, str>,
     #[serde(default)]
     pub yes_price: Option<i64>,
     #[serde(default)]
     pub no_price: Option<i64>,
-    #[serde(default, borrow)]
-    pub yes_price_dollars: Option<Cow<'a, str>>,
-    #[serde(default, borrow)]
-    pub no_price_dollars: Option<Cow<'a, str>>,
-    #[serde(default)]
-    pub taker_side: Option<TradeTakerSide>,
+    #[serde(borrow)]
+    pub yes_price_dollars: Cow<'a, str>,
+    #[serde(borrow)]
+    pub no_price_dollars: Cow<'a, str>,
+    pub taker_side: TradeTakerSide,
+    pub ts: i64,
+    pub ts_ms: i64,
     #[serde(default, borrow)]
     pub created_time: Option<Cow<'a, str>>,
 }
@@ -931,15 +1016,17 @@ impl<'a> WsTradeRef<'a> {
     pub fn into_owned(self) -> WsTrade {
         WsTrade {
             trade_id: self.trade_id.into_owned(),
-            ticker: self.ticker.into_owned(),
+            market_ticker: self.market_ticker.into_owned(),
             price: self.price,
             count: self.count,
-            count_fp: self.count_fp.map(Cow::into_owned),
+            count_fp: self.count_fp.into_owned(),
             yes_price: self.yes_price,
             no_price: self.no_price,
-            yes_price_dollars: self.yes_price_dollars.map(Cow::into_owned),
-            no_price_dollars: self.no_price_dollars.map(Cow::into_owned),
+            yes_price_dollars: self.yes_price_dollars.into_owned(),
+            no_price_dollars: self.no_price_dollars.into_owned(),
             taker_side: self.taker_side,
+            ts: self.ts,
+            ts_ms: self.ts_ms,
             created_time: self.created_time.map(Cow::into_owned),
         }
     }
@@ -1010,9 +1097,11 @@ pub struct WsOrderbookDeltaRef<'a> {
     pub market_ticker: Cow<'a, str>,
     #[serde(borrow)]
     pub market_id: Cow<'a, str>,
+    #[serde(default)]
     pub price: i64,
     #[serde(borrow)]
     pub price_dollars: Cow<'a, str>,
+    #[serde(default)]
     pub delta: i64,
     #[serde(borrow)]
     pub delta_fp: Cow<'a, str>,
@@ -1023,6 +1112,8 @@ pub struct WsOrderbookDeltaRef<'a> {
     pub subaccount: Option<i64>,
     #[serde(default, borrow)]
     pub ts: Option<Cow<'a, str>>,
+    #[serde(default)]
+    pub ts_ms: Option<i64>,
 }
 
 impl<'a> WsOrderbookDeltaRef<'a> {
@@ -1038,6 +1129,7 @@ impl<'a> WsOrderbookDeltaRef<'a> {
             client_order_id: self.client_order_id.map(Cow::into_owned),
             subaccount: self.subaccount,
             ts: self.ts.map(Cow::into_owned),
+            ts_ms: self.ts_ms,
         }
     }
 }
@@ -1046,47 +1138,48 @@ impl<'a> WsOrderbookDeltaRef<'a> {
 #[derive(Debug, Clone, Deserialize)]
 pub struct WsFillRef<'a> {
     #[serde(borrow)]
-    pub fill_id: Cow<'a, str>,
-    #[serde(borrow)]
     pub trade_id: Cow<'a, str>,
     #[serde(borrow)]
     pub order_id: Cow<'a, str>,
     #[serde(default, borrow)]
     pub client_order_id: Option<Cow<'a, str>>,
-    #[serde(borrow)]
-    pub ticker: Cow<'a, str>,
-    #[serde(borrow)]
+    #[serde(alias = "ticker", borrow)]
     pub market_ticker: Cow<'a, str>,
     pub side: YesNo,
     pub action: BuySell,
+    #[serde(default)]
     pub count: i64,
     #[serde(borrow)]
     pub count_fp: Cow<'a, str>,
+    #[serde(default)]
     pub yes_price: i64,
+    #[serde(default)]
     pub no_price: i64,
-    #[serde(alias = "yes_price_dollars", borrow)]
-    pub yes_price_fixed: Cow<'a, str>,
-    #[serde(alias = "no_price_dollars", borrow)]
-    pub no_price_fixed: Cow<'a, str>,
+    #[serde(alias = "yes_price_fixed", borrow)]
+    pub yes_price_dollars: Cow<'a, str>,
+    #[serde(default, alias = "no_price_fixed", borrow)]
+    pub no_price_dollars: Option<Cow<'a, str>>,
     pub is_taker: bool,
     #[serde(borrow)]
     pub fee_cost: Cow<'a, str>,
+    pub ts: i64,
+    pub ts_ms: i64,
+    #[serde(borrow)]
+    pub post_position_fp: Cow<'a, str>,
+    pub purchased_side: YesNo,
     #[serde(default, borrow)]
     pub created_time: Option<Cow<'a, str>>,
     #[serde(default)]
-    pub subaccount_number: Option<i64>,
-    #[serde(default)]
-    pub ts: Option<i64>,
+    #[serde(alias = "subaccount_number")]
+    pub subaccount: Option<i64>,
 }
 
 impl<'a> WsFillRef<'a> {
     pub fn into_owned(self) -> WsFill {
         WsFill {
-            fill_id: self.fill_id.into_owned(),
             trade_id: self.trade_id.into_owned(),
             order_id: self.order_id.into_owned(),
             client_order_id: self.client_order_id.map(Cow::into_owned),
-            ticker: self.ticker.into_owned(),
             market_ticker: self.market_ticker.into_owned(),
             side: self.side,
             action: self.action,
@@ -1094,13 +1187,16 @@ impl<'a> WsFillRef<'a> {
             count_fp: self.count_fp.into_owned(),
             yes_price: self.yes_price,
             no_price: self.no_price,
-            yes_price_fixed: self.yes_price_fixed.into_owned(),
-            no_price_fixed: self.no_price_fixed.into_owned(),
+            yes_price_dollars: self.yes_price_dollars.into_owned(),
+            no_price_dollars: self.no_price_dollars.map(Cow::into_owned),
             is_taker: self.is_taker,
             fee_cost: self.fee_cost.into_owned(),
-            created_time: self.created_time.map(Cow::into_owned),
-            subaccount_number: self.subaccount_number,
             ts: self.ts,
+            ts_ms: self.ts_ms,
+            post_position_fp: self.post_position_fp.into_owned(),
+            purchased_side: self.purchased_side,
+            created_time: self.created_time.map(Cow::into_owned),
+            subaccount: self.subaccount,
         }
     }
 }
@@ -1117,6 +1213,20 @@ pub struct WsMarketLifecycleV2Ref<'a> {
     #[serde(default)]
     pub close_ts: Option<i64>,
     #[serde(default, borrow)]
+    pub result: Option<Cow<'a, str>>,
+    #[serde(default)]
+    pub determination_ts: Option<i64>,
+    #[serde(default, borrow)]
+    pub settlement_value: Option<Cow<'a, str>>,
+    #[serde(default)]
+    pub settled_ts: Option<i64>,
+    #[serde(default)]
+    pub is_deactivated: Option<bool>,
+    #[serde(default)]
+    pub fractional_trading_enabled: Option<bool>,
+    #[serde(default, borrow)]
+    pub price_level_structure: Option<Cow<'a, str>>,
+    #[serde(default, borrow)]
     pub additional_metadata: Option<WsMarketLifecycleAdditionalMetadataRef<'a>>,
 }
 
@@ -1127,6 +1237,13 @@ impl<'a> WsMarketLifecycleV2Ref<'a> {
             event_type: self.event_type,
             open_ts: self.open_ts,
             close_ts: self.close_ts,
+            result: self.result.map(Cow::into_owned),
+            determination_ts: self.determination_ts,
+            settlement_value: self.settlement_value.map(Cow::into_owned),
+            settled_ts: self.settled_ts,
+            is_deactivated: self.is_deactivated,
+            fractional_trading_enabled: self.fractional_trading_enabled,
+            price_level_structure: self.price_level_structure.map(Cow::into_owned),
             additional_metadata: self
                 .additional_metadata
                 .map(WsMarketLifecycleAdditionalMetadataRef::into_owned),
@@ -1157,7 +1274,9 @@ pub struct WsMarketLifecycleAdditionalMetadataRef<'a> {
     #[serde(default, borrow)]
     pub strike_type: Option<Cow<'a, str>>,
     #[serde(default)]
-    pub floor_strike: Option<i64>,
+    pub floor_strike: Option<f64>,
+    #[serde(default)]
+    pub cap_strike: Option<f64>,
     #[serde(default)]
     pub custom_strike: Option<BTreeMap<String, String>>,
     #[serde(default, flatten)]
@@ -1178,6 +1297,7 @@ impl<'a> WsMarketLifecycleAdditionalMetadataRef<'a> {
             expected_expiration_ts: self.expected_expiration_ts,
             strike_type: self.strike_type.map(Cow::into_owned),
             floor_strike: self.floor_strike,
+            cap_strike: self.cap_strike,
             custom_strike: self.custom_strike,
             extra: self.extra,
         }
@@ -1198,6 +1318,10 @@ pub struct WsEventLifecycleRef<'a> {
     #[serde(default, borrow)]
     pub series_ticker: Option<Cow<'a, str>>,
     #[serde(default)]
+    pub strike_date: Option<i64>,
+    #[serde(default, borrow)]
+    pub strike_period: Option<Cow<'a, str>>,
+    #[serde(default)]
     pub additional_metadata: Option<WsEventLifecycleAdditionalMetadataRef>,
 }
 
@@ -1209,6 +1333,8 @@ impl<'a> WsEventLifecycleRef<'a> {
             subtitle: self.subtitle.map(Cow::into_owned),
             collateral_return_type: self.collateral_return_type.map(Cow::into_owned),
             series_ticker: self.series_ticker.map(Cow::into_owned),
+            strike_date: self.strike_date,
+            strike_period: self.strike_period.map(Cow::into_owned),
             additional_metadata: self
                 .additional_metadata
                 .map(WsEventLifecycleAdditionalMetadataRef::into_owned),
@@ -1233,28 +1359,41 @@ impl WsEventLifecycleAdditionalMetadataRef {
     }
 }
 
-/// Market positions message (type: "market_positions")
+/// Market position message (type: "market_position")
 #[derive(Debug, Clone, Deserialize)]
-pub struct WsMarketPositionsRef<'a> {
-    #[serde(default, borrow)]
-    pub market_positions: Vec<MarketPositionRef<'a>>,
-    #[serde(default, borrow)]
-    pub event_positions: Vec<EventPositionRef<'a>>,
+pub struct WsMarketPositionRef<'a> {
+    #[serde(borrow)]
+    pub user_id: Cow<'a, str>,
+    #[serde(borrow)]
+    pub market_ticker: Cow<'a, str>,
+    #[serde(borrow)]
+    pub position_fp: FixedPointCountRef<'a>,
+    #[serde(borrow)]
+    pub position_cost_dollars: FixedPointDollarsRef<'a>,
+    #[serde(borrow)]
+    pub realized_pnl_dollars: FixedPointDollarsRef<'a>,
+    #[serde(borrow)]
+    pub fees_paid_dollars: FixedPointDollarsRef<'a>,
+    #[serde(borrow)]
+    pub position_fee_cost_dollars: FixedPointDollarsRef<'a>,
+    #[serde(borrow)]
+    pub volume_fp: FixedPointCountRef<'a>,
+    #[serde(default)]
+    pub subaccount: Option<u32>,
 }
 
-impl<'a> WsMarketPositionsRef<'a> {
-    pub fn into_owned(self) -> WsMarketPositions {
-        WsMarketPositions {
-            market_positions: self
-                .market_positions
-                .into_iter()
-                .map(MarketPositionRef::into_owned)
-                .collect(),
-            event_positions: self
-                .event_positions
-                .into_iter()
-                .map(EventPositionRef::into_owned)
-                .collect(),
+impl<'a> WsMarketPositionRef<'a> {
+    pub fn into_owned(self) -> WsMarketPosition {
+        WsMarketPosition {
+            user_id: self.user_id.into_owned(),
+            market_ticker: self.market_ticker.into_owned(),
+            position_fp: self.position_fp.into_owned(),
+            position_cost_dollars: self.position_cost_dollars.into_owned(),
+            realized_pnl_dollars: self.realized_pnl_dollars.into_owned(),
+            fees_paid_dollars: self.fees_paid_dollars.into_owned(),
+            position_fee_cost_dollars: self.position_fee_cost_dollars.into_owned(),
+            volume_fp: self.volume_fp.into_owned(),
+            subaccount: self.subaccount,
         }
     }
 }
@@ -1671,7 +1810,7 @@ impl WsEnvelope {
         self.msg.as_deref().map(|raw| raw.get())
     }
 
-    pub fn into_message(self) -> Result<WsMessage, KalshiError> {
+    pub fn into_message(self) -> Result<WsMessageV2, KalshiError> {
         fn parse_msg<T: for<'de> Deserialize<'de>>(
             msg: &Option<Box<RawValue>>,
         ) -> Result<T, serde_json::Error> {
@@ -1684,7 +1823,7 @@ impl WsEnvelope {
         #[derive(Deserialize)]
         struct SubscribedMsg {
             #[allow(dead_code)]
-            channel: Option<WsChannel>,
+            channel: Option<WsChannelV2>,
             sid: Option<u64>,
         }
 
@@ -1704,16 +1843,16 @@ impl WsEnvelope {
                         .ok()
                         .and_then(|value| value.sid)
                 });
-                Ok(WsMessage::Subscribed { id, sid })
+                Ok(WsMessageV2::Subscribed { id, sid })
             }
-            WsMsgType::Unsubscribed => Ok(WsMessage::Unsubscribed { id, sid }),
+            WsMsgType::Unsubscribed => Ok(WsMessageV2::Unsubscribed { id, sid }),
             WsMsgType::Ok => {
                 if msg.is_some()
                     && let Ok(subscriptions) = parse_msg::<Vec<WsSubscriptionInfo>>(&msg)
                 {
-                    return Ok(WsMessage::ListSubscriptions { id, subscriptions });
+                    return Ok(WsMessageV2::ListSubscriptions { id, subscriptions });
                 }
-                Ok(WsMessage::Ok { id })
+                Ok(WsMessageV2::Ok { id })
             }
             WsMsgType::ListSubscriptions => {
                 let subs = if msg.is_some() {
@@ -1722,7 +1861,7 @@ impl WsEnvelope {
                 } else {
                     subscriptions.unwrap_or_default()
                 };
-                Ok(WsMessage::ListSubscriptions {
+                Ok(WsMessageV2::ListSubscriptions {
                     id,
                     subscriptions: subs,
                 })
@@ -1736,95 +1875,108 @@ impl WsEnvelope {
                         message: None,
                     }
                 };
-                Ok(WsMessage::Error { id, error })
+                Ok(WsMessageV2::Error { id, error })
             }
-            WsMsgType::Ticker => Ok(WsMessage::Data(WsDataMessage::Ticker {
+            WsMsgType::Ticker => Ok(WsMessageV2::Data(WsDataMessageV2::Ticker {
                 sid,
                 seq,
                 msg: parse_msg(&msg)?,
             })),
-            WsMsgType::Trade => Ok(WsMessage::Data(WsDataMessage::Trade {
+            WsMsgType::Trade => Ok(WsMessageV2::Data(WsDataMessageV2::Trade {
                 sid,
                 seq,
                 msg: parse_msg(&msg)?,
             })),
-            WsMsgType::OrderbookSnapshot => Ok(WsMessage::Data(WsDataMessage::OrderbookSnapshot {
-                sid,
-                seq,
-                msg: parse_msg(&msg)?,
-            })),
-            WsMsgType::OrderbookDelta => Ok(WsMessage::Data(WsDataMessage::OrderbookDelta {
-                sid,
-                seq,
-                msg: parse_msg(&msg)?,
-            })),
-            WsMsgType::Fill => Ok(WsMessage::Data(WsDataMessage::Fill {
-                sid,
-                seq,
-                msg: parse_msg(&msg)?,
-            })),
-            WsMsgType::MarketPositions => Ok(WsMessage::Data(WsDataMessage::MarketPositions {
-                sid,
-                seq,
-                msg: parse_msg(&msg)?,
-            })),
-            WsMsgType::MarketLifecycleV2 => Ok(WsMessage::Data(WsDataMessage::MarketLifecycleV2 {
-                sid,
-                seq,
-                msg: parse_msg(&msg)?,
-            })),
-            WsMsgType::EventLifecycle => Ok(WsMessage::Data(WsDataMessage::EventLifecycle {
-                sid,
-                seq,
-                msg: parse_msg(&msg)?,
-            })),
-            WsMsgType::Multivariate | WsMsgType::MultivariateLookup => {
-                Ok(WsMessage::Data(WsDataMessage::Multivariate {
+            WsMsgType::OrderbookSnapshot => {
+                Ok(WsMessageV2::Data(WsDataMessageV2::OrderbookSnapshot {
                     sid,
                     seq,
                     msg: parse_msg(&msg)?,
                 }))
             }
-            WsMsgType::RfqCreated => Ok(WsMessage::Data(WsDataMessage::Communications {
+            WsMsgType::OrderbookDelta => Ok(WsMessageV2::Data(WsDataMessageV2::OrderbookDelta {
+                sid,
+                seq,
+                msg: parse_msg(&msg)?,
+            })),
+            WsMsgType::Fill => Ok(WsMessageV2::Data(WsDataMessageV2::Fill {
+                sid,
+                seq,
+                msg: parse_msg(&msg)?,
+            })),
+            WsMsgType::MarketPosition => Ok(WsMessageV2::Data(WsDataMessageV2::MarketPosition {
+                sid,
+                seq,
+                msg: parse_msg(&msg)?,
+            })),
+            WsMsgType::MarketLifecycleV2 => {
+                Ok(WsMessageV2::Data(WsDataMessageV2::MarketLifecycleV2 {
+                    sid,
+                    seq,
+                    msg: parse_msg(&msg)?,
+                }))
+            }
+            WsMsgType::MultivariateMarketLifecycle => Ok(WsMessageV2::Data(
+                WsDataMessageV2::MultivariateMarketLifecycle {
+                    sid,
+                    seq,
+                    msg: parse_msg(&msg)?,
+                },
+            )),
+            WsMsgType::EventLifecycle => Ok(WsMessageV2::Data(WsDataMessageV2::EventLifecycle {
+                sid,
+                seq,
+                msg: parse_msg(&msg)?,
+            })),
+            WsMsgType::Multivariate | WsMsgType::MultivariateLookup => {
+                Ok(WsMessageV2::Data(WsDataMessageV2::Multivariate {
+                    sid,
+                    seq,
+                    msg: parse_msg(&msg)?,
+                }))
+            }
+            WsMsgType::RfqCreated => Ok(WsMessageV2::Data(WsDataMessageV2::Communications {
                 sid,
                 seq,
                 msg: WsCommunications::RfqCreated(parse_msg(&msg)?),
             })),
-            WsMsgType::RfqDeleted => Ok(WsMessage::Data(WsDataMessage::Communications {
+            WsMsgType::RfqDeleted => Ok(WsMessageV2::Data(WsDataMessageV2::Communications {
                 sid,
                 seq,
                 msg: WsCommunications::RfqDeleted(parse_msg(&msg)?),
             })),
-            WsMsgType::QuoteCreated => Ok(WsMessage::Data(WsDataMessage::Communications {
+            WsMsgType::QuoteCreated => Ok(WsMessageV2::Data(WsDataMessageV2::Communications {
                 sid,
                 seq,
                 msg: WsCommunications::QuoteCreated(parse_msg(&msg)?),
             })),
-            WsMsgType::QuoteAccepted => Ok(WsMessage::Data(WsDataMessage::Communications {
+            WsMsgType::QuoteAccepted => Ok(WsMessageV2::Data(WsDataMessageV2::Communications {
                 sid,
                 seq,
                 msg: WsCommunications::QuoteAccepted(parse_msg(&msg)?),
             })),
-            WsMsgType::QuoteExecuted => Ok(WsMessage::Data(WsDataMessage::Communications {
+            WsMsgType::QuoteExecuted => Ok(WsMessageV2::Data(WsDataMessageV2::Communications {
                 sid,
                 seq,
                 msg: WsCommunications::QuoteExecuted(parse_msg(&msg)?),
             })),
-            WsMsgType::OrderGroupUpdates => Ok(WsMessage::Data(WsDataMessage::OrderGroupUpdates {
+            WsMsgType::OrderGroupUpdates => {
+                Ok(WsMessageV2::Data(WsDataMessageV2::OrderGroupUpdates {
+                    sid,
+                    seq,
+                    msg: parse_msg(&msg)?,
+                }))
+            }
+            WsMsgType::UserOrder => Ok(WsMessageV2::Data(WsDataMessageV2::UserOrder {
                 sid,
                 seq,
                 msg: parse_msg(&msg)?,
             })),
-            WsMsgType::UserOrder => Ok(WsMessage::Data(WsDataMessage::UserOrder {
-                sid,
-                seq,
-                msg: parse_msg(&msg)?,
-            })),
-            WsMsgType::Communications => Ok(WsMessage::Unknown {
+            WsMsgType::Communications => Ok(WsMessageV2::Unknown {
                 msg_type: WsMsgType::Communications,
                 raw: msg,
             }),
-            other => Ok(WsMessage::Unknown {
+            other => Ok(WsMessageV2::Unknown {
                 msg_type: other,
                 raw: msg,
             }),
@@ -1861,7 +2013,7 @@ impl<'a> WsEnvelopeRef<'a> {
         #[derive(Deserialize)]
         struct SubscribedMsg {
             #[allow(dead_code)]
-            channel: Option<WsChannel>,
+            channel: Option<WsChannelV2>,
             sid: Option<u64>,
         }
 
@@ -1943,13 +2095,11 @@ impl<'a> WsEnvelopeRef<'a> {
                 seq,
                 msg: parse_borrowed_msg(msg)?,
             })),
-            WsMsgType::MarketPositions => {
-                Ok(WsMessageRef::Data(WsDataMessageRef::MarketPositions {
-                    sid,
-                    seq,
-                    msg: parse_borrowed_msg(msg)?,
-                }))
-            }
+            WsMsgType::MarketPosition => Ok(WsMessageRef::Data(WsDataMessageRef::MarketPosition {
+                sid,
+                seq,
+                msg: parse_borrowed_msg(msg)?,
+            })),
             WsMsgType::MarketLifecycleV2 => {
                 Ok(WsMessageRef::Data(WsDataMessageRef::MarketLifecycleV2 {
                     sid,
@@ -1957,6 +2107,13 @@ impl<'a> WsEnvelopeRef<'a> {
                     msg: parse_borrowed_msg(msg)?,
                 }))
             }
+            WsMsgType::MultivariateMarketLifecycle => Ok(WsMessageRef::Data(
+                WsDataMessageRef::MultivariateMarketLifecycle {
+                    sid,
+                    seq,
+                    msg: parse_borrowed_msg(msg)?,
+                },
+            )),
             WsMsgType::EventLifecycle => Ok(WsMessageRef::Data(WsDataMessageRef::EventLifecycle {
                 sid,
                 seq,
@@ -2033,7 +2190,7 @@ pub struct WsError {
 }
 
 #[derive(Debug, Clone)]
-pub enum WsMessage {
+pub enum WsMessageV2 {
     Subscribed {
         id: Option<u64>,
         sid: Option<u64>,
@@ -2053,7 +2210,7 @@ pub enum WsMessage {
         id: Option<u64>,
         error: WsError,
     },
-    Data(WsDataMessage),
+    Data(WsDataMessageV2),
     Unknown {
         msg_type: WsMsgType,
         raw: Option<Box<RawValue>>,
@@ -2061,7 +2218,7 @@ pub enum WsMessage {
 }
 
 #[derive(Debug, Clone)]
-pub enum WsDataMessage {
+pub enum WsDataMessageV2 {
     Ticker {
         sid: Option<u64>,
         seq: Option<u64>,
@@ -2087,12 +2244,17 @@ pub enum WsDataMessage {
         seq: Option<u64>,
         msg: WsFill,
     },
-    MarketPositions {
+    MarketPosition {
         sid: Option<u64>,
         seq: Option<u64>,
-        msg: WsMarketPositions,
+        msg: WsMarketPosition,
     },
     MarketLifecycleV2 {
+        sid: Option<u64>,
+        seq: Option<u64>,
+        msg: WsMarketLifecycleV2,
+    },
+    MultivariateMarketLifecycle {
         sid: Option<u64>,
         seq: Option<u64>,
         msg: WsMarketLifecycleV2,
@@ -2151,12 +2313,17 @@ pub enum WsDataMessageRef<'a> {
         seq: Option<u64>,
         msg: WsFillRef<'a>,
     },
-    MarketPositions {
+    MarketPosition {
         sid: Option<u64>,
         seq: Option<u64>,
-        msg: WsMarketPositionsRef<'a>,
+        msg: WsMarketPositionRef<'a>,
     },
     MarketLifecycleV2 {
+        sid: Option<u64>,
+        seq: Option<u64>,
+        msg: WsMarketLifecycleV2Ref<'a>,
+    },
+    MultivariateMarketLifecycle {
         sid: Option<u64>,
         seq: Option<u64>,
         msg: WsMarketLifecycleV2Ref<'a>,
@@ -2189,71 +2356,78 @@ pub enum WsDataMessageRef<'a> {
 }
 
 impl<'a> WsDataMessageRef<'a> {
-    pub fn into_owned(self) -> WsDataMessage {
+    pub fn into_owned(self) -> WsDataMessageV2 {
         match self {
-            WsDataMessageRef::Ticker { sid, seq, msg } => WsDataMessage::Ticker {
+            WsDataMessageRef::Ticker { sid, seq, msg } => WsDataMessageV2::Ticker {
                 sid,
                 seq,
                 msg: msg.into_owned(),
             },
-            WsDataMessageRef::Trade { sid, seq, msg } => WsDataMessage::Trade {
+            WsDataMessageRef::Trade { sid, seq, msg } => WsDataMessageV2::Trade {
                 sid,
                 seq,
                 msg: msg.into_owned(),
             },
             WsDataMessageRef::OrderbookSnapshot { sid, seq, msg } => {
-                WsDataMessage::OrderbookSnapshot {
+                WsDataMessageV2::OrderbookSnapshot {
                     sid,
                     seq,
                     msg: msg.into_owned(),
                 }
             }
-            WsDataMessageRef::OrderbookDelta { sid, seq, msg } => WsDataMessage::OrderbookDelta {
+            WsDataMessageRef::OrderbookDelta { sid, seq, msg } => WsDataMessageV2::OrderbookDelta {
                 sid,
                 seq,
                 msg: msg.into_owned(),
             },
-            WsDataMessageRef::Fill { sid, seq, msg } => WsDataMessage::Fill {
+            WsDataMessageRef::Fill { sid, seq, msg } => WsDataMessageV2::Fill {
                 sid,
                 seq,
                 msg: msg.into_owned(),
             },
-            WsDataMessageRef::MarketPositions { sid, seq, msg } => WsDataMessage::MarketPositions {
+            WsDataMessageRef::MarketPosition { sid, seq, msg } => WsDataMessageV2::MarketPosition {
                 sid,
                 seq,
                 msg: msg.into_owned(),
             },
             WsDataMessageRef::MarketLifecycleV2 { sid, seq, msg } => {
-                WsDataMessage::MarketLifecycleV2 {
+                WsDataMessageV2::MarketLifecycleV2 {
                     sid,
                     seq,
                     msg: msg.into_owned(),
                 }
             }
-            WsDataMessageRef::EventLifecycle { sid, seq, msg } => WsDataMessage::EventLifecycle {
+            WsDataMessageRef::MultivariateMarketLifecycle { sid, seq, msg } => {
+                WsDataMessageV2::MultivariateMarketLifecycle {
+                    sid,
+                    seq,
+                    msg: msg.into_owned(),
+                }
+            }
+            WsDataMessageRef::EventLifecycle { sid, seq, msg } => WsDataMessageV2::EventLifecycle {
                 sid,
                 seq,
                 msg: msg.into_owned(),
             },
-            WsDataMessageRef::Multivariate { sid, seq, msg } => WsDataMessage::Multivariate {
+            WsDataMessageRef::Multivariate { sid, seq, msg } => WsDataMessageV2::Multivariate {
                 sid,
                 seq,
                 msg: msg.into_owned(),
             },
-            WsDataMessageRef::Communications { sid, seq, msg } => WsDataMessage::Communications {
+            WsDataMessageRef::Communications { sid, seq, msg } => WsDataMessageV2::Communications {
                 sid,
                 seq,
                 msg: msg.into_owned(),
             },
             WsDataMessageRef::OrderGroupUpdates { sid, seq, msg } => {
-                WsDataMessage::OrderGroupUpdates {
+                WsDataMessageV2::OrderGroupUpdates {
                     sid,
                     seq,
                     msg: msg.into_owned(),
                 }
             }
             WsDataMessageRef::UserOrder { sid, seq, msg } => {
-                WsDataMessage::UserOrder { sid, seq, msg }
+                WsDataMessageV2::UserOrder { sid, seq, msg }
             }
         }
     }
@@ -2292,29 +2466,31 @@ pub enum WsMessageRef<'a> {
 }
 
 impl<'a> WsMessageRef<'a> {
-    pub fn into_owned(self) -> Result<WsMessage, KalshiError> {
+    pub fn into_owned(self) -> Result<WsMessageV2, KalshiError> {
         let owned = match self {
-            WsMessageRef::Subscribed { id, sid } => WsMessage::Subscribed { id, sid },
-            WsMessageRef::Unsubscribed { id, sid } => WsMessage::Unsubscribed { id, sid },
-            WsMessageRef::ListSubscriptions { id, subscriptions } => WsMessage::ListSubscriptions {
-                id,
-                subscriptions: subscriptions
-                    .into_iter()
-                    .map(WsSubscriptionInfoRef::into_owned)
-                    .collect(),
-            },
-            WsMessageRef::Ok { id } => WsMessage::Ok { id },
-            WsMessageRef::Error { id, error } => WsMessage::Error {
+            WsMessageRef::Subscribed { id, sid } => WsMessageV2::Subscribed { id, sid },
+            WsMessageRef::Unsubscribed { id, sid } => WsMessageV2::Unsubscribed { id, sid },
+            WsMessageRef::ListSubscriptions { id, subscriptions } => {
+                WsMessageV2::ListSubscriptions {
+                    id,
+                    subscriptions: subscriptions
+                        .into_iter()
+                        .map(WsSubscriptionInfoRef::into_owned)
+                        .collect(),
+                }
+            }
+            WsMessageRef::Ok { id } => WsMessageV2::Ok { id },
+            WsMessageRef::Error { id, error } => WsMessageV2::Error {
                 id,
                 error: error.into_owned(),
             },
-            WsMessageRef::Data(data) => WsMessage::Data(data.into_owned()),
+            WsMessageRef::Data(data) => WsMessageV2::Data(data.into_owned()),
             WsMessageRef::Unknown { msg_type, raw } => {
                 let raw_owned = match raw {
                     Some(value) => Some(serde_json::from_str::<Box<RawValue>>(value.get())?),
                     None => None,
                 };
-                WsMessage::Unknown {
+                WsMessageV2::Unknown {
                     msg_type,
                     raw: raw_owned,
                 }
@@ -2346,8 +2522,8 @@ impl WsRawEvent {
         std::str::from_utf8(&self.bytes).ok()
     }
 
-    pub fn parse_owned(&self) -> Result<WsMessage, KalshiError> {
-        WsMessage::from_bytes(&self.bytes)
+    pub fn parse_owned(&self) -> Result<WsMessageV2, KalshiError> {
+        WsMessageV2::from_bytes(&self.bytes)
     }
 
     pub fn parse_borrowed(&self) -> Result<WsMessageRef<'_>, KalshiError> {
@@ -2359,18 +2535,18 @@ impl WsRawEvent {
 pub(crate) struct WsSubscribeCmd {
     pub id: u64,
     pub cmd: &'static str, // "subscribe"
-    pub params: WsSubscriptionParams,
+    pub params: WsSubscriptionParamsV2,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct WsUnsubscribeCmd {
     pub id: u64,
     pub cmd: &'static str,
-    pub params: WsUnsubscribeParams,
+    pub params: WsUnsubscribeParamsV2,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WsUnsubscribeParams {
+pub struct WsUnsubscribeParamsV2 {
     pub sids: Vec<u64>,
 }
 
@@ -2384,11 +2560,11 @@ pub(crate) struct WsListSubscriptionsCmd {
 pub(crate) struct WsUpdateSubscriptionCmd {
     pub id: u64,
     pub cmd: &'static str,
-    pub params: WsUpdateSubscriptionParams,
+    pub params: WsUpdateSubscriptionParamsV2,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WsUpdateSubscriptionParams {
+pub struct WsUpdateSubscriptionParamsV2 {
     pub action: WsUpdateAction,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sid: Option<u64>,
@@ -2404,9 +2580,11 @@ pub struct WsUpdateSubscriptionParams {
     pub market_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub send_initial_snapshot: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skip_ticker_ack: Option<bool>,
 }
 
-impl WsUpdateSubscriptionParams {
+impl WsUpdateSubscriptionParamsV2 {
     pub fn target_sid(&self) -> Option<u64> {
         self.sid.or_else(|| {
             self.sids
@@ -2423,7 +2601,7 @@ pub enum WsUpdateAction {
     DeleteMarkets,
 }
 
-pub(crate) fn validate_update(params: &WsUpdateSubscriptionParams) -> Result<(), KalshiError> {
+pub(crate) fn validate_update(params: &WsUpdateSubscriptionParamsV2) -> Result<(), KalshiError> {
     let has_sid = params.sid.is_some();
     let has_sids = params.sids.is_some();
     if has_sid == has_sids {
@@ -2441,7 +2619,7 @@ pub(crate) fn validate_update(params: &WsUpdateSubscriptionParams) -> Result<(),
     Ok(())
 }
 
-pub(crate) fn validate_subscription(params: &WsSubscriptionParams) -> Result<(), KalshiError> {
+pub(crate) fn validate_subscription(params: &WsSubscriptionParamsV2) -> Result<(), KalshiError> {
     if params.channels.is_empty() {
         return Err(KalshiError::InvalidParams(
             "subscribe: at least one channel is required".to_string(),
@@ -2482,19 +2660,25 @@ pub(crate) fn validate_subscription(params: &WsSubscriptionParams) -> Result<(),
     let has_orderbook_delta = params
         .channels
         .iter()
-        .any(|c| matches!(c, WsChannel::OrderbookDelta));
+        .any(|c| matches!(c, WsChannelV2::OrderbookDelta));
     let has_market_positions = params
         .channels
         .iter()
-        .any(|c| matches!(c, WsChannel::MarketPositions));
+        .any(|c| matches!(c, WsChannelV2::MarketPositions));
     let has_communications = params
         .channels
         .iter()
-        .any(|c| matches!(c, WsChannel::Communications));
+        .any(|c| matches!(c, WsChannelV2::Communications));
 
-    if has_orderbook_delta && !(has_any_market_tickers || has_any_market_ids) {
+    if has_orderbook_delta && !has_any_market_tickers {
         return Err(KalshiError::InvalidParams(
-            "subscribe: orderbook_delta requires market_tickers or market_ids".to_string(),
+            "subscribe: orderbook_delta requires market_ticker or market_tickers".to_string(),
+        ));
+    }
+
+    if has_orderbook_delta && has_any_market_ids {
+        return Err(KalshiError::InvalidParams(
+            "subscribe: orderbook_delta does not support market_id or market_ids".to_string(),
         ));
     }
 
@@ -2587,14 +2771,20 @@ enum WsWireMessage {
         seq: Option<u64>,
         msg: WsFill,
     },
-    #[serde(rename = "market_positions")]
-    MarketPositions {
+    #[serde(rename = "market_position", alias = "market_positions")]
+    MarketPosition {
         sid: Option<u64>,
         seq: Option<u64>,
-        msg: WsMarketPositions,
+        msg: WsMarketPosition,
     },
     #[serde(rename = "market_lifecycle_v2")]
     MarketLifecycleV2 {
+        sid: Option<u64>,
+        seq: Option<u64>,
+        msg: WsMarketLifecycleV2,
+    },
+    #[serde(rename = "multivariate_market_lifecycle")]
+    MultivariateMarketLifecycle {
         sid: Option<u64>,
         seq: Option<u64>,
         msg: WsMarketLifecycleV2,
@@ -2664,26 +2854,26 @@ enum WsWireMessage {
 #[derive(Debug, Deserialize)]
 struct WsSubscribedMsg {
     #[allow(dead_code)]
-    channel: Option<WsChannel>,
+    channel: Option<WsChannelV2>,
     sid: Option<u64>,
 }
 
 impl WsWireMessage {
-    fn into_message(self) -> WsMessage {
+    fn into_message(self) -> WsMessageV2 {
         match self {
-            WsWireMessage::Subscribed { id, sid, msg } => WsMessage::Subscribed {
+            WsWireMessage::Subscribed { id, sid, msg } => WsMessageV2::Subscribed {
                 id,
                 sid: sid.or_else(|| msg.and_then(|value| value.sid)),
             },
-            WsWireMessage::Unsubscribed { id, sid } => WsMessage::Unsubscribed { id, sid },
+            WsWireMessage::Unsubscribed { id, sid } => WsMessageV2::Unsubscribed { id, sid },
             WsWireMessage::Ok { id, msg } => {
                 if let Some(msg) = msg
                     && let Ok(subscriptions) =
                         serde_json::from_value::<Vec<WsSubscriptionInfo>>(msg)
                 {
-                    return WsMessage::ListSubscriptions { id, subscriptions };
+                    return WsMessageV2::ListSubscriptions { id, subscriptions };
                 }
-                WsMessage::Ok { id }
+                WsMessageV2::Ok { id }
             }
             WsWireMessage::ListSubscriptions {
                 id,
@@ -2693,12 +2883,12 @@ impl WsWireMessage {
                 let subs = msg
                     .map(|value| value.subscriptions)
                     .unwrap_or(subscriptions);
-                WsMessage::ListSubscriptions {
+                WsMessageV2::ListSubscriptions {
                     id,
                     subscriptions: subs,
                 }
             }
-            WsWireMessage::Error { id, msg } => WsMessage::Error {
+            WsWireMessage::Error { id, msg } => WsMessageV2::Error {
                 id,
                 error: msg.unwrap_or(WsError {
                     code: None,
@@ -2706,73 +2896,76 @@ impl WsWireMessage {
                 }),
             },
             WsWireMessage::Ticker { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::Ticker { sid, seq, msg })
+                WsMessageV2::Data(WsDataMessageV2::Ticker { sid, seq, msg })
             }
             WsWireMessage::Trade { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::Trade { sid, seq, msg })
+                WsMessageV2::Data(WsDataMessageV2::Trade { sid, seq, msg })
             }
             WsWireMessage::OrderbookSnapshot { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::OrderbookSnapshot { sid, seq, msg })
+                WsMessageV2::Data(WsDataMessageV2::OrderbookSnapshot { sid, seq, msg })
             }
             WsWireMessage::OrderbookDelta { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::OrderbookDelta { sid, seq, msg })
+                WsMessageV2::Data(WsDataMessageV2::OrderbookDelta { sid, seq, msg })
             }
             WsWireMessage::Fill { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::Fill { sid, seq, msg })
+                WsMessageV2::Data(WsDataMessageV2::Fill { sid, seq, msg })
             }
-            WsWireMessage::MarketPositions { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::MarketPositions { sid, seq, msg })
+            WsWireMessage::MarketPosition { sid, seq, msg } => {
+                WsMessageV2::Data(WsDataMessageV2::MarketPosition { sid, seq, msg })
             }
             WsWireMessage::MarketLifecycleV2 { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::MarketLifecycleV2 { sid, seq, msg })
+                WsMessageV2::Data(WsDataMessageV2::MarketLifecycleV2 { sid, seq, msg })
+            }
+            WsWireMessage::MultivariateMarketLifecycle { sid, seq, msg } => {
+                WsMessageV2::Data(WsDataMessageV2::MultivariateMarketLifecycle { sid, seq, msg })
             }
             WsWireMessage::EventLifecycle { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::EventLifecycle { sid, seq, msg })
+                WsMessageV2::Data(WsDataMessageV2::EventLifecycle { sid, seq, msg })
             }
             WsWireMessage::Multivariate { sid, seq, msg }
             | WsWireMessage::MultivariateLookup { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::Multivariate { sid, seq, msg })
+                WsMessageV2::Data(WsDataMessageV2::Multivariate { sid, seq, msg })
             }
             WsWireMessage::RfqCreated { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::Communications {
+                WsMessageV2::Data(WsDataMessageV2::Communications {
                     sid,
                     seq,
                     msg: WsCommunications::RfqCreated(msg),
                 })
             }
             WsWireMessage::RfqDeleted { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::Communications {
+                WsMessageV2::Data(WsDataMessageV2::Communications {
                     sid,
                     seq,
                     msg: WsCommunications::RfqDeleted(msg),
                 })
             }
             WsWireMessage::QuoteCreated { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::Communications {
+                WsMessageV2::Data(WsDataMessageV2::Communications {
                     sid,
                     seq,
                     msg: WsCommunications::QuoteCreated(msg),
                 })
             }
             WsWireMessage::QuoteAccepted { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::Communications {
+                WsMessageV2::Data(WsDataMessageV2::Communications {
                     sid,
                     seq,
                     msg: WsCommunications::QuoteAccepted(msg),
                 })
             }
             WsWireMessage::QuoteExecuted { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::Communications {
+                WsMessageV2::Data(WsDataMessageV2::Communications {
                     sid,
                     seq,
                     msg: WsCommunications::QuoteExecuted(msg),
                 })
             }
             WsWireMessage::OrderGroupUpdates { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::OrderGroupUpdates { sid, seq, msg })
+                WsMessageV2::Data(WsDataMessageV2::OrderGroupUpdates { sid, seq, msg })
             }
             WsWireMessage::UserOrder { sid, seq, msg } => {
-                WsMessage::Data(WsDataMessage::UserOrder { sid, seq, msg })
+                WsMessageV2::Data(WsDataMessageV2::UserOrder { sid, seq, msg })
             }
         }
     }
@@ -2845,15 +3038,22 @@ enum WsWireMessageRef<'a> {
         #[serde(borrow)]
         msg: WsFillRef<'a>,
     },
-    #[serde(rename = "market_positions")]
-    MarketPositions {
+    #[serde(rename = "market_position", alias = "market_positions")]
+    MarketPosition {
         sid: Option<u64>,
         seq: Option<u64>,
         #[serde(borrow)]
-        msg: WsMarketPositionsRef<'a>,
+        msg: WsMarketPositionRef<'a>,
     },
     #[serde(rename = "market_lifecycle_v2")]
     MarketLifecycleV2 {
+        sid: Option<u64>,
+        seq: Option<u64>,
+        #[serde(borrow)]
+        msg: WsMarketLifecycleV2Ref<'a>,
+    },
+    #[serde(rename = "multivariate_market_lifecycle")]
+    MultivariateMarketLifecycle {
         sid: Option<u64>,
         seq: Option<u64>,
         #[serde(borrow)]
@@ -2933,7 +3133,7 @@ enum WsWireMessageRef<'a> {
 #[derive(Debug, Deserialize)]
 struct WsSubscribedMsgRef {
     #[allow(dead_code)]
-    channel: Option<WsChannel>,
+    channel: Option<WsChannelV2>,
     #[serde(default)]
     sid: Option<u64>,
 }
@@ -2990,11 +3190,14 @@ impl<'a> WsWireMessageRef<'a> {
             WsWireMessageRef::Fill { sid, seq, msg } => {
                 WsMessageRef::Data(WsDataMessageRef::Fill { sid, seq, msg })
             }
-            WsWireMessageRef::MarketPositions { sid, seq, msg } => {
-                WsMessageRef::Data(WsDataMessageRef::MarketPositions { sid, seq, msg })
+            WsWireMessageRef::MarketPosition { sid, seq, msg } => {
+                WsMessageRef::Data(WsDataMessageRef::MarketPosition { sid, seq, msg })
             }
             WsWireMessageRef::MarketLifecycleV2 { sid, seq, msg } => {
                 WsMessageRef::Data(WsDataMessageRef::MarketLifecycleV2 { sid, seq, msg })
+            }
+            WsWireMessageRef::MultivariateMarketLifecycle { sid, seq, msg } => {
+                WsMessageRef::Data(WsDataMessageRef::MultivariateMarketLifecycle { sid, seq, msg })
             }
             WsWireMessageRef::EventLifecycle { sid, seq, msg } => {
                 WsMessageRef::Data(WsDataMessageRef::EventLifecycle { sid, seq, msg })
@@ -3048,7 +3251,7 @@ impl<'a> WsWireMessageRef<'a> {
     }
 }
 
-impl WsMessage {
+impl WsMessageV2 {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, KalshiError> {
         match serde_json::from_slice::<WsWireMessage>(bytes) {
             Ok(wire) => Ok(wire.into_message()),
@@ -3103,14 +3306,14 @@ mod tests {
 
     #[test]
     fn validate_subscription_requires_market_tickers_for_orderbook_delta() {
-        let params = WsSubscriptionParams {
-            channels: vec![WsChannel::OrderbookDelta],
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::OrderbookDelta],
             ..Default::default()
         };
         assert!(validate_subscription(&params).is_err());
 
-        let params = WsSubscriptionParams {
-            channels: vec![WsChannel::OrderbookDelta],
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::OrderbookDelta],
             market_tickers: Some(vec!["TEST".to_string()]),
             ..Default::default()
         };
@@ -3119,8 +3322,8 @@ mod tests {
 
     #[test]
     fn validate_subscription_send_initial_snapshot_only_for_orderbook_delta() {
-        let params = WsSubscriptionParams {
-            channels: vec![WsChannel::Ticker],
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::Ticker],
             send_initial_snapshot: Some(true),
             ..Default::default()
         };
@@ -3128,19 +3331,19 @@ mod tests {
     }
 
     #[test]
-    fn validate_subscription_orderbook_delta_allows_market_ids() {
-        let params = WsSubscriptionParams {
-            channels: vec![WsChannel::OrderbookDelta],
+    fn validate_subscription_orderbook_delta_rejects_market_ids() {
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::OrderbookDelta],
             market_ids: Some(vec!["mid-1".to_string()]),
             ..Default::default()
         };
-        assert!(validate_subscription(&params).is_ok());
+        assert!(validate_subscription(&params).is_err());
     }
 
     #[test]
     fn validate_subscription_rejects_market_positions_with_market_ids() {
-        let params = WsSubscriptionParams {
-            channels: vec![WsChannel::MarketPositions],
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::MarketPositions],
             market_ids: Some(vec!["mid-1".to_string()]),
             ..Default::default()
         };
@@ -3149,15 +3352,15 @@ mod tests {
 
     #[test]
     fn validate_subscription_shard_fields_require_communications() {
-        let params = WsSubscriptionParams {
-            channels: vec![WsChannel::Ticker],
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::Ticker],
             shard_factor: Some(2),
             ..Default::default()
         };
         assert!(validate_subscription(&params).is_err());
 
-        let params = WsSubscriptionParams {
-            channels: vec![WsChannel::Communications],
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::Communications],
             shard_factor: Some(2),
             shard_key: Some(1),
             ..Default::default()
@@ -3167,8 +3370,8 @@ mod tests {
 
     #[test]
     fn validate_subscription_send_initial_snapshot_with_orderbook_delta_ok() {
-        let params = WsSubscriptionParams {
-            channels: vec![WsChannel::OrderbookDelta],
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::OrderbookDelta],
             market_tickers: Some(vec!["TEST".to_string()]),
             send_initial_snapshot: Some(true),
             ..Default::default()
@@ -3197,24 +3400,27 @@ mod tests {
             "msg":{
                 "market_ticker":"TEST",
                 "market_id":"1",
-                "price":1,
-                "yes_bid":1,
-                "yes_ask":2,
                 "price_dollars":"0.01",
                 "yes_bid_dollars":"0.01",
                 "yes_ask_dollars":"0.02",
-                "volume":0,
+                "yes_bid_size_fp":"1.00",
+                "yes_ask_size_fp":"2.00",
+                "last_trade_size_fp":"1.00",
                 "volume_fp":"0",
-                "open_interest":0,
                 "open_interest_fp":"0",
                 "dollar_volume":0,
                 "dollar_open_interest":0,
-                "ts":0
+                "ts":0,
+                "ts_ms":0,
+                "time":"1970-01-01T00:00:00Z"
             }
         }"#;
         let env: WsEnvelope = serde_json::from_str(json).unwrap();
         let msg = env.into_message().unwrap();
-        assert!(matches!(msg, WsMessage::Data(WsDataMessage::Ticker { .. })));
+        assert!(matches!(
+            msg,
+            WsMessageV2::Data(WsDataMessageV2::Ticker { .. })
+        ));
     }
 
     #[test]
@@ -3223,7 +3429,7 @@ mod tests {
         let env: WsEnvelope = serde_json::from_str(json).unwrap();
         let msg = env.into_message().unwrap();
         match msg {
-            WsMessage::Unknown {
+            WsMessageV2::Unknown {
                 msg_type: WsMsgType::Unknown(value),
                 raw,
             } => {
@@ -3243,31 +3449,34 @@ mod tests {
             "msg":{
                 "market_ticker":"TEST",
                 "market_id":"1",
-                "price":1,
-                "yes_bid":1,
-                "yes_ask":2,
                 "price_dollars":"0.01",
                 "yes_bid_dollars":"0.01",
                 "yes_ask_dollars":"0.02",
-                "volume":0,
+                "yes_bid_size_fp":"1.00",
+                "yes_ask_size_fp":"2.00",
+                "last_trade_size_fp":"1.00",
                 "volume_fp":"0",
-                "open_interest":0,
                 "open_interest_fp":"0",
                 "dollar_volume":0,
                 "dollar_open_interest":0,
-                "ts":0
+                "ts":0,
+                "ts_ms":0,
+                "time":"1970-01-01T00:00:00Z"
             }
         }"#;
-        let msg = WsMessage::from_bytes(json.as_bytes()).unwrap();
-        assert!(matches!(msg, WsMessage::Data(WsDataMessage::Ticker { .. })));
+        let msg = WsMessageV2::from_bytes(json.as_bytes()).unwrap();
+        assert!(matches!(
+            msg,
+            WsMessageV2::Data(WsDataMessageV2::Ticker { .. })
+        ));
     }
 
     #[test]
     fn ws_message_from_bytes_unknown_type() {
         let json = r#"{"type":"mystery","msg":{"foo":1}}"#;
-        let msg = WsMessage::from_bytes(json.as_bytes()).unwrap();
+        let msg = WsMessageV2::from_bytes(json.as_bytes()).unwrap();
         match msg {
-            WsMessage::Unknown {
+            WsMessageV2::Unknown {
                 msg_type: WsMsgType::Unknown(value),
                 raw,
             } => {
@@ -3281,7 +3490,7 @@ mod tests {
     #[test]
     fn ws_message_from_bytes_invalid_json_exposes_raw_bytes_and_reason() {
         let raw = br#"{"type":"ticker","msg":{"market_ticker":"TEST"}"#;
-        let err = WsMessage::from_bytes(raw).expect_err("invalid JSON should fail");
+        let err = WsMessageV2::from_bytes(raw).expect_err("invalid JSON should fail");
         match err {
             KalshiError::Parse {
                 context,
@@ -3301,7 +3510,7 @@ mod tests {
     #[test]
     fn ws_message_from_bytes_payload_parse_error_exposes_raw_bytes_and_reason() {
         let raw = br#"{"type":"ticker","sid":1,"seq":2,"msg":{"market_ticker":"TEST"}}"#;
-        let err = WsMessage::from_bytes(raw).expect_err("invalid payload should fail");
+        let err = WsMessageV2::from_bytes(raw).expect_err("invalid payload should fail");
         assert_eq!(err.parse_context(), Some("websocket message payload"));
         assert_eq!(err.parse_raw_bytes(), Some(&raw[..]));
         let reason = err
@@ -3318,21 +3527,21 @@ mod tests {
             "seq":4,
             "msg":{
                 "trade_id":"t1",
-                "ticker":"TST",
-                "price":10,
-                "count":2,
+                "market_ticker":"TST",
                 "count_fp":"2",
-                "yes_price":10,
-                "no_price":90,
                 "yes_price_dollars":"0.10",
                 "no_price_dollars":"0.90",
                 "taker_side":"yes",
-                "created_time":"2024-01-01T00:00:00Z"
+                "ts":1704067200,
+                "ts_ms":1704067200000
             }
         }"#;
         let msg_ref = WsMessageRef::from_bytes(json.as_bytes()).unwrap();
         let msg = msg_ref.into_owned().unwrap();
-        assert!(matches!(msg, WsMessage::Data(WsDataMessage::Trade { .. })));
+        assert!(matches!(
+            msg,
+            WsMessageV2::Data(WsDataMessageV2::Trade { .. })
+        ));
     }
 
     #[test]
@@ -3344,19 +3553,19 @@ mod tests {
             "msg":{
                 "market_ticker":"TEST",
                 "market_id":"1",
-                "price":1,
-                "yes_bid":1,
-                "yes_ask":2,
                 "price_dollars":"0.01",
                 "yes_bid_dollars":"0.01",
                 "yes_ask_dollars":"0.02",
-                "volume":0,
+                "yes_bid_size_fp":"1.00",
+                "yes_ask_size_fp":"2.00",
+                "last_trade_size_fp":"1.00",
                 "volume_fp":"0",
-                "open_interest":0,
                 "open_interest_fp":"0",
                 "dollar_volume":0,
                 "dollar_open_interest":0,
-                "ts":0
+                "ts":0,
+                "ts_ms":0,
+                "time":"1970-01-01T00:00:00Z"
             }
         }"#;
         let raw = WsRawEvent::new(Bytes::from(json));
@@ -3385,21 +3594,19 @@ mod tests {
     #[test]
     fn ws_fill_side_action_parse() {
         let json = r#"{
-            "fill_id":"f",
             "trade_id":"t",
             "order_id":"o",
-            "ticker":"T",
-            "market_ticker":"M",
+            "market_ticker":"T",
             "side":"no",
             "action":"buy",
-            "count":1,
             "count_fp":"1",
-            "yes_price":1,
-            "no_price":2,
             "yes_price_dollars":"0.01",
-            "no_price_dollars":"0.02",
             "is_taker":true,
-            "fee_cost":"0.00"
+            "fee_cost":"0.00",
+            "ts":0,
+            "ts_ms":0,
+            "post_position_fp":"1.00",
+            "purchased_side":"yes"
         }"#;
         let fill: WsFill = serde_json::from_str(json).unwrap();
         assert!(matches!(fill.side, YesNo::No));
@@ -3408,7 +3615,7 @@ mod tests {
 
     #[test]
     fn validate_update_requires_exactly_one_sid_target() {
-        let both = WsUpdateSubscriptionParams {
+        let both = WsUpdateSubscriptionParamsV2 {
             action: WsUpdateAction::AddMarkets,
             sid: Some(1),
             sids: Some(vec![2]),
@@ -3417,10 +3624,11 @@ mod tests {
             market_id: None,
             market_ids: None,
             send_initial_snapshot: None,
+            skip_ticker_ack: None,
         };
         assert!(validate_update(&both).is_err());
 
-        let multi = WsUpdateSubscriptionParams {
+        let multi = WsUpdateSubscriptionParamsV2 {
             action: WsUpdateAction::AddMarkets,
             sid: None,
             sids: Some(vec![1, 2]),
@@ -3429,10 +3637,11 @@ mod tests {
             market_id: None,
             market_ids: None,
             send_initial_snapshot: None,
+            skip_ticker_ack: None,
         };
         assert!(validate_update(&multi).is_err());
 
-        let valid = WsUpdateSubscriptionParams {
+        let valid = WsUpdateSubscriptionParamsV2 {
             action: WsUpdateAction::DeleteMarkets,
             sid: Some(1),
             sids: None,
@@ -3441,22 +3650,23 @@ mod tests {
             market_id: None,
             market_ids: None,
             send_initial_snapshot: None,
+            skip_ticker_ack: None,
         };
         assert!(validate_update(&valid).is_ok());
     }
 
     #[test]
     fn validate_subscription_enforces_market_target_exclusivity() {
-        let params = WsSubscriptionParams {
-            channels: vec![WsChannel::Ticker],
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::Ticker],
             market_ticker: Some("A".to_string()),
             market_tickers: Some(vec!["B".to_string()]),
             ..Default::default()
         };
         assert!(validate_subscription(&params).is_err());
 
-        let params = WsSubscriptionParams {
-            channels: vec![WsChannel::Ticker],
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::Ticker],
             market_ticker: Some("A".to_string()),
             market_id: Some("uuid".to_string()),
             ..Default::default()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,7 @@
-use kalshi_fast::{KalshiAuth, KalshiEnvironment};
+use kalshi_fast::{KalshiAuth, KalshiEnvironment, KalshiRestClient, RateLimitConfig, RetryConfig};
 use std::time::Duration;
 
-pub const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+pub const TEST_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[allow(dead_code)]
 pub fn load_env() {
@@ -27,4 +27,39 @@ pub fn load_auth() -> KalshiAuth {
 
 pub fn demo_env() -> KalshiEnvironment {
     KalshiEnvironment::demo()
+}
+
+pub fn demo_client() -> KalshiRestClient {
+    KalshiRestClient::builder(demo_env())
+        .with_rate_limit_config(RateLimitConfig {
+            read_rps: 4,
+            write_rps: 2,
+        })
+        .with_retry_config(RetryConfig {
+            max_retries: 5,
+            base_delay: Duration::from_millis(500),
+            max_delay: Duration::from_secs(6),
+            jitter: 0.0,
+            retry_non_idempotent: false,
+        })
+        .build()
+        .expect("build live test client")
+}
+
+pub fn demo_auth_client(auth: KalshiAuth) -> KalshiRestClient {
+    KalshiRestClient::builder(demo_env())
+        .with_auth(auth)
+        .with_rate_limit_config(RateLimitConfig {
+            read_rps: 4,
+            write_rps: 2,
+        })
+        .with_retry_config(RetryConfig {
+            max_retries: 5,
+            base_delay: Duration::from_millis(500),
+            max_delay: Duration::from_secs(6),
+            jitter: 0.0,
+            retry_non_idempotent: false,
+        })
+        .build()
+        .expect("build authenticated live test client")
 }

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -430,6 +430,7 @@ fn historical_params_serialize_correctly() {
         limit: Some(100),
         cursor: Some("c2".into()),
         tickers: Some("MKT-1,MKT-2".into()),
+        series_ticker: None,
         event_ticker: Some("EVT-1".into()),
         mve_filter: Some(MveFilter::Exclude),
     };
@@ -903,7 +904,7 @@ fn get_market_orderbook_response_deserializes() {
 
     let resp: GetMarketOrderbookResponse = serde_json::from_str(json).unwrap();
     assert_eq!(resp.orderbook.yes.len(), 1);
-    assert!(resp.orderbook_fp.is_some());
+    assert_eq!(resp.orderbook_fp.yes_dollars.len(), 1);
 }
 
 #[test]
@@ -1676,6 +1677,95 @@ fn batch_order_responses_deserialize_typed() {
         serde_json::from_str(cancel_json).unwrap();
     assert_eq!(canceled.orders.len(), 1);
     assert_eq!(canceled.orders[0].reduced_by_fp, "1.00");
+}
+
+#[test]
+fn fills_deserialize_current_and_legacy_price_fields() {
+    let current_json = r#"{
+        "fills": [{
+            "fill_id": "f-1",
+            "order_id": "o-1",
+            "trade_id": "t-1",
+            "ticker": "MKT-1",
+            "count_fp": "1.00",
+            "yes_price_dollars": "0.5500",
+            "no_price_dollars": "0.4500"
+        }]
+    }"#;
+    let current: kalshi_fast::GetFillsResponse = serde_json::from_str(current_json).unwrap();
+    assert_eq!(
+        current.fills[0].yes_price_dollars.as_deref(),
+        Some("0.5500")
+    );
+    assert_eq!(current.fills[0].no_price_dollars.as_deref(), Some("0.4500"));
+
+    let legacy_json = r#"{
+        "fills": [{
+            "fill_id": "f-2",
+            "order_id": "o-2",
+            "trade_id": "t-2",
+            "ticker": "MKT-2",
+            "count_fp": "2.00",
+            "yes_price_fixed": "0.6000",
+            "no_price_fixed": "0.4000"
+        }]
+    }"#;
+    let legacy: kalshi_fast::GetFillsResponse = serde_json::from_str(legacy_json).unwrap();
+    assert_eq!(legacy.fills[0].yes_price_dollars.as_deref(), Some("0.6000"));
+    assert_eq!(legacy.fills[0].no_price_dollars.as_deref(), Some("0.4000"));
+}
+
+#[test]
+fn settlements_deserialize_current_and_legacy_cost_fields() {
+    let current_json = r#"{
+        "settlements": [{
+            "settlement_id": "s-1",
+            "ticker": "MKT-1",
+            "yes_count_fp": "1.00",
+            "yes_total_cost_dollars": "0.5500",
+            "no_count_fp": "0.00",
+            "no_total_cost_dollars": "0.0000",
+            "revenue": "1.0000",
+            "settled_time": "2026-04-02T00:00:00Z",
+            "fee_cost": "0.0100",
+            "value": "0.9900",
+            "created_time": "2026-04-02T00:00:00Z"
+        }]
+    }"#;
+    let current: kalshi_fast::GetSettlementsResponse = serde_json::from_str(current_json).unwrap();
+    assert_eq!(
+        current.settlements[0].yes_total_cost_dollars.as_deref(),
+        Some("0.5500")
+    );
+    assert_eq!(
+        current.settlements[0].no_total_cost_dollars.as_deref(),
+        Some("0.0000")
+    );
+
+    let legacy_json = r#"{
+        "settlements": [{
+            "settlement_id": "s-2",
+            "ticker": "MKT-2",
+            "yes_count_fp": "1.00",
+            "yes_total_cost": "0.6500",
+            "no_count_fp": "0.00",
+            "no_total_cost": "0.0000",
+            "revenue": "1.0000",
+            "settled_time": "2026-04-02T00:00:00Z",
+            "fee_cost": "0.0100",
+            "value": "0.9900",
+            "created_time": "2026-04-02T00:00:00Z"
+        }]
+    }"#;
+    let legacy: kalshi_fast::GetSettlementsResponse = serde_json::from_str(legacy_json).unwrap();
+    assert_eq!(
+        legacy.settlements[0].yes_total_cost_dollars.as_deref(),
+        Some("0.6500")
+    );
+    assert_eq!(
+        legacy.settlements[0].no_total_cost_dollars.as_deref(),
+        Some("0.0000")
+    );
 }
 
 #[test]

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -890,12 +890,6 @@ fn cancel_order_response_deserializes() {
 #[test]
 fn get_market_orderbook_response_deserializes() {
     let json = r#"{
-        "orderbook": {
-            "yes": [[50, 100]],
-            "no": [[49, 200]],
-            "yes_dollars": [["0.50", 100]],
-            "no_dollars": [["0.49", 200]]
-        },
         "orderbook_fp": {
             "yes_dollars": [["0.50", "100.00"]],
             "no_dollars": [["0.49", "200.00"]]
@@ -903,23 +897,6 @@ fn get_market_orderbook_response_deserializes() {
     }"#;
 
     let resp: GetMarketOrderbookResponse = serde_json::from_str(json).unwrap();
-    assert_eq!(resp.orderbook.unwrap().yes.len(), 1);
-    assert!(resp.orderbook_fp.is_some());
-}
-
-#[test]
-fn get_market_orderbook_response_deserializes_fp_only_shape() {
-    let json = r#"{
-        "orderbook_fp": {
-            "yes_dollars": [["0.50", "100.00"]],
-            "no_dollars": [["0.49", "200.00"]]
-        }
-    }"#;
-
-    let resp: GetMarketOrderbookResponse = serde_json::from_str(json).unwrap();
-    assert!(resp.orderbook.is_none());
-    assert!(resp.orderbook_fp.is_some());
-    assert_eq!(resp.orderbook.yes.len(), 1);
     assert_eq!(resp.orderbook_fp.yes_dollars.len(), 1);
 }
 

--- a/tests/rest_auth.rs
+++ b/tests/rest_auth.rs
@@ -13,7 +13,7 @@ use kalshi_fast::{
 async fn test_get_balance() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async { client.get_balance().await })
         .await
@@ -30,7 +30,7 @@ async fn test_get_balance() {
 async fn test_get_positions() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -52,7 +52,7 @@ async fn test_get_positions() {
 async fn test_get_orders() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -74,7 +74,7 @@ async fn test_get_orders() {
 async fn test_get_fills() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -95,7 +95,7 @@ async fn test_get_fills() {
 async fn test_get_settlements() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -116,7 +116,7 @@ async fn test_get_settlements() {
 async fn test_get_account_api_limits() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_account_api_limits().await
@@ -133,7 +133,7 @@ async fn test_get_account_api_limits() {
 async fn test_get_subaccount_balances() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_subaccount_balances().await
@@ -151,7 +151,7 @@ async fn test_get_subaccount_balances() {
 async fn test_get_subaccount_transfers() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -170,7 +170,7 @@ async fn test_get_subaccount_transfers() {
 
 #[tokio::test]
 async fn test_auth_required_without_auth() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
 
     let result =
         tokio::time::timeout(common::TEST_TIMEOUT, async { client.get_balance().await }).await;
@@ -189,7 +189,7 @@ async fn test_auth_required_without_auth() {
 async fn test_get_portfolio_total_resting_order_value() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_portfolio_total_resting_order_value().await
@@ -205,7 +205,7 @@ async fn test_get_portfolio_total_resting_order_value() {
 async fn test_get_api_keys() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let _resp = tokio::time::timeout(common::TEST_TIMEOUT, async { client.get_api_keys().await })
         .await
@@ -217,7 +217,7 @@ async fn test_get_api_keys() {
 async fn test_get_communications_id() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_communications_id().await
@@ -233,7 +233,7 @@ async fn test_get_communications_id() {
 async fn test_get_order_groups() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let _resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -249,7 +249,7 @@ async fn test_get_order_groups() {
 async fn test_get_order_queue_positions() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let _resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -265,7 +265,7 @@ async fn test_get_order_queue_positions() {
 async fn test_get_rfqs() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_rfqs(GetRFQsParams::default()).await
@@ -282,7 +282,7 @@ async fn test_get_rfqs() {
 async fn test_get_quotes() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_quotes(GetQuotesParams::default()).await
@@ -299,7 +299,7 @@ async fn test_get_quotes() {
 async fn test_get_event_forecast_percentile_history() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     // First find an open event with a series_ticker
     let events_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
@@ -355,7 +355,7 @@ async fn test_get_event_forecast_percentile_history() {
 async fn test_get_subaccount_transfers_all() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let transfers = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -377,7 +377,7 @@ async fn test_get_subaccount_transfers_all() {
 async fn test_get_rfqs_all() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let rfqs = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_rfqs_all(GetRFQsParams::default()).await
@@ -393,7 +393,7 @@ async fn test_get_rfqs_all() {
 async fn test_get_quotes_all() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let quotes = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_quotes_all(GetQuotesParams::default()).await
@@ -409,7 +409,7 @@ async fn test_get_quotes_all() {
 async fn test_get_subaccount_netting() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     let _resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_subaccount_netting().await

--- a/tests/rest_communications.rs
+++ b/tests/rest_communications.rs
@@ -13,7 +13,7 @@ const LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(30);
 async fn test_rfq_lifecycle() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     // Find an open market
     let markets_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
@@ -81,7 +81,7 @@ async fn test_rfq_lifecycle() {
 async fn test_quote_lifecycle() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     // Find an open market
     let markets_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {

--- a/tests/rest_order_groups.rs
+++ b/tests/rest_order_groups.rs
@@ -13,7 +13,7 @@ const LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(30);
 async fn test_order_group_lifecycle() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     // 1. Create an order group
     let create_resp = tokio::time::timeout(LIFECYCLE_TIMEOUT, async {

--- a/tests/rest_orders.rs
+++ b/tests/rest_orders.rs
@@ -16,7 +16,7 @@ const LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(30);
 async fn test_order_lifecycle() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     // 1. Find an open market
     let markets_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
@@ -140,7 +140,7 @@ async fn test_order_lifecycle() {
 async fn test_batch_order_lifecycle() {
     common::load_env();
     let auth = common::load_auth();
-    let client = KalshiRestClient::new(common::demo_env()).with_auth(auth);
+    let client = common::demo_auth_client(auth);
 
     // 1. Find an open market
     let markets_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {

--- a/tests/rest_public.rs
+++ b/tests/rest_public.rs
@@ -12,7 +12,7 @@ use kalshi_fast::{
 
 #[tokio::test]
 async fn test_get_series_list() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_series_list(GetSeriesListParams::default()).await
     })
@@ -26,7 +26,7 @@ async fn test_get_series_list() {
 
 #[tokio::test]
 async fn test_get_series_by_ticker() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let list_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_series_list(GetSeriesListParams::default()).await
     })
@@ -51,7 +51,7 @@ async fn test_get_series_by_ticker() {
 
 #[tokio::test]
 async fn test_get_events() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_events(GetEventsParams {
@@ -70,7 +70,7 @@ async fn test_get_events() {
 
 #[tokio::test]
 async fn test_get_events_all() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let events = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_events_all(GetEventsParams {
@@ -92,7 +92,7 @@ async fn test_get_events_all() {
 
 #[tokio::test]
 async fn test_get_event_by_ticker() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
 
     // First get an event ticker from the events list
     let events_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
@@ -127,7 +127,7 @@ async fn test_get_event_by_ticker() {
 
 #[tokio::test]
 async fn test_get_markets() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_markets(GetMarketsParams {
@@ -146,7 +146,7 @@ async fn test_get_markets() {
 
 #[tokio::test]
 async fn test_get_market_by_ticker() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
 
     // First get a market ticker from the markets list
     let markets_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
@@ -181,7 +181,7 @@ async fn test_get_market_by_ticker() {
 
 #[tokio::test]
 async fn test_get_market_orderbook() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
 
     let markets_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -214,7 +214,7 @@ async fn test_get_market_orderbook() {
 
 #[tokio::test]
 async fn test_get_trades() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
 
     let markets_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -252,7 +252,7 @@ async fn test_get_trades() {
 
 #[tokio::test]
 async fn test_get_exchange_status() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_exchange_status().await
     })
@@ -267,7 +267,7 @@ async fn test_get_exchange_status() {
 
 #[tokio::test]
 async fn test_get_exchange_announcements() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_exchange_announcements().await
     })
@@ -282,7 +282,7 @@ async fn test_get_exchange_announcements() {
 
 #[tokio::test]
 async fn test_get_exchange_schedule() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_exchange_schedule().await
     })
@@ -298,7 +298,7 @@ async fn test_get_exchange_schedule() {
 
 #[tokio::test]
 async fn test_get_user_data_timestamp() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_user_data_timestamp().await
     })
@@ -311,7 +311,7 @@ async fn test_get_user_data_timestamp() {
 
 #[tokio::test]
 async fn test_get_series_fee_changes() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_series_fee_changes(GetSeriesFeeChangesParams::default())
@@ -328,7 +328,7 @@ async fn test_get_series_fee_changes() {
 
 #[tokio::test]
 async fn test_get_multivariate_events() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_multivariate_events(GetMultivariateEventsParams {
@@ -346,7 +346,7 @@ async fn test_get_multivariate_events() {
 
 #[tokio::test]
 async fn test_get_event_metadata() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
 
     let events_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -376,7 +376,7 @@ async fn test_get_event_metadata() {
 
 #[tokio::test]
 async fn test_get_milestones() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_milestones(GetMilestonesParams {
@@ -394,7 +394,7 @@ async fn test_get_milestones() {
 
 #[tokio::test]
 async fn test_get_milestone() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
 
     let milestones_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -428,7 +428,7 @@ async fn test_get_milestone() {
 
 #[tokio::test]
 async fn test_get_multivariate_event_collections() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_multivariate_event_collections(GetMultivariateEventCollectionsParams {
@@ -446,7 +446,7 @@ async fn test_get_multivariate_event_collections() {
 
 #[tokio::test]
 async fn test_get_multivariate_event_collection() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
 
     let collections_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -479,7 +479,7 @@ async fn test_get_multivariate_event_collection() {
 
 #[tokio::test]
 async fn test_get_multivariate_event_collection_lookup_history() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
 
     let collections_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -515,7 +515,7 @@ async fn test_get_multivariate_event_collection_lookup_history() {
 
 #[tokio::test]
 async fn test_get_structured_targets() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_structured_targets(GetStructuredTargetsParams {
@@ -533,7 +533,7 @@ async fn test_get_structured_targets() {
 
 #[tokio::test]
 async fn test_get_structured_target() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
 
     let targets_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -570,7 +570,7 @@ async fn test_get_structured_target() {
 
 #[tokio::test]
 async fn test_get_tags_by_categories() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let _resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_tags_by_categories().await
     })
@@ -581,7 +581,7 @@ async fn test_get_tags_by_categories() {
 
 #[tokio::test]
 async fn test_get_filters_by_sport() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let _resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_filters_by_sport().await
     })
@@ -592,7 +592,7 @@ async fn test_get_filters_by_sport() {
 
 #[tokio::test]
 async fn test_batch_get_market_candlesticks() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
 
     let markets_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -634,7 +634,7 @@ async fn test_batch_get_market_candlesticks() {
 
 #[tokio::test]
 async fn test_get_market_candlesticks() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
 
     let markets_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -685,7 +685,7 @@ async fn test_get_market_candlesticks() {
 
 #[tokio::test]
 async fn test_get_event_market_candlesticks() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
 
     let events_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -735,7 +735,7 @@ async fn test_get_event_market_candlesticks() {
 
 #[tokio::test]
 async fn test_get_incentive_programs() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     // May not be available on demo - just verify the endpoint doesn't panic
     let _resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -749,7 +749,7 @@ async fn test_get_incentive_programs() {
 
 #[tokio::test]
 async fn test_get_markets_all() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let markets = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_markets_all(GetMarketsParams {
@@ -770,7 +770,7 @@ async fn test_get_markets_all() {
 
 #[tokio::test]
 async fn test_get_trades_all() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
 
     let markets_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
@@ -810,7 +810,7 @@ async fn test_get_trades_all() {
 
 #[tokio::test]
 async fn test_get_milestones_all() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let milestones = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_milestones_all(GetMilestonesParams {
@@ -830,7 +830,7 @@ async fn test_get_milestones_all() {
 
 #[tokio::test]
 async fn test_get_multivariate_events_all() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let events = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_multivariate_events_all(GetMultivariateEventsParams {
@@ -850,7 +850,7 @@ async fn test_get_multivariate_events_all() {
 
 #[tokio::test]
 async fn test_get_multivariate_event_collections_all() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let collections = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_multivariate_event_collections_all(GetMultivariateEventCollectionsParams {
@@ -870,7 +870,7 @@ async fn test_get_multivariate_event_collections_all() {
 
 #[tokio::test]
 async fn test_get_structured_targets_all() {
-    let client = KalshiRestClient::new(common::demo_env());
+    let client = common::demo_client();
     let targets = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_structured_targets_all(GetStructuredTargetsParams {

--- a/tests/ws_auth.rs
+++ b/tests/ws_auth.rs
@@ -3,8 +3,8 @@
 mod common;
 
 use kalshi_fast::{
-    GetMarketsParams, KalshiRestClient, KalshiWsLowLevelClient, MarketStatusQuery, WsChannel,
-    WsDataMessage, WsMessage, WsSubscriptionParams,
+    GetMarketsParams, KalshiRestClient, KalshiWsLowLevelClient, MarketStatusQuery, WsChannelV2,
+    WsDataMessageV2, WsMessageV2, WsSubscriptionParamsV2,
 };
 use std::time::Duration;
 
@@ -30,7 +30,7 @@ async fn test_ws_orderbook_delta_subscribe() {
     let auth = common::load_auth();
 
     // First get an open market ticker via REST
-    let rest_client = KalshiRestClient::new(common::demo_env());
+    let rest_client = common::demo_client();
     let markets_resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         rest_client
             .get_markets(GetMarketsParams {
@@ -60,8 +60,8 @@ async fn test_ws_orderbook_delta_subscribe() {
 
     // Subscribe to OrderbookDelta (private channel) with market ticker
     let sub_id = ws
-        .subscribe(WsSubscriptionParams {
-            channels: vec![WsChannel::OrderbookDelta],
+        .subscribe_v2(WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::OrderbookDelta],
             market_tickers: Some(vec![market_ticker]),
             ..Default::default()
         })
@@ -71,15 +71,17 @@ async fn test_ws_orderbook_delta_subscribe() {
     assert!(sub_id > 0);
 
     // Read first message
-    let msg = tokio::time::timeout(Duration::from_secs(10), async { ws.next_message().await })
-        .await
-        .expect("timeout")
-        .expect("receive failed");
+    let msg = tokio::time::timeout(Duration::from_secs(10), async {
+        ws.next_message_v2().await
+    })
+    .await
+    .expect("timeout")
+    .expect("receive failed");
 
     match msg {
-        WsMessage::Subscribed { .. } => {}
-        WsMessage::Data(WsDataMessage::OrderbookDelta { .. }) => {}
-        WsMessage::Data(WsDataMessage::OrderbookSnapshot { .. }) => {}
+        WsMessageV2::Subscribed { .. } => {}
+        WsMessageV2::Data(WsDataMessageV2::OrderbookDelta { .. }) => {}
+        WsMessageV2::Data(WsDataMessageV2::OrderbookSnapshot { .. }) => {}
         other => panic!("unexpected message: {:?}", other),
     }
 }
@@ -98,8 +100,8 @@ async fn test_ws_fill_subscribe() {
 
     // Subscribe to Fill channel (private, no market ticker needed)
     let sub_id = ws
-        .subscribe(WsSubscriptionParams {
-            channels: vec![WsChannel::Fill],
+        .subscribe_v2(WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::Fill],
             ..Default::default()
         })
         .await
@@ -108,14 +110,16 @@ async fn test_ws_fill_subscribe() {
     assert!(sub_id > 0);
 
     // Read first message (should be subscribed confirmation)
-    let msg = tokio::time::timeout(Duration::from_secs(10), async { ws.next_message().await })
-        .await
-        .expect("timeout")
-        .expect("receive failed");
+    let msg = tokio::time::timeout(Duration::from_secs(10), async {
+        ws.next_message_v2().await
+    })
+    .await
+    .expect("timeout")
+    .expect("receive failed");
 
     match msg {
-        WsMessage::Subscribed { .. } => {}
-        WsMessage::Data(WsDataMessage::Fill { .. }) => {}
+        WsMessageV2::Subscribed { .. } => {}
+        WsMessageV2::Data(WsDataMessageV2::Fill { .. }) => {}
         other => panic!("unexpected message: {:?}", other),
     }
 }

--- a/tests/ws_command_behavior.rs
+++ b/tests/ws_command_behavior.rs
@@ -1,0 +1,182 @@
+use std::net::SocketAddr;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use futures::StreamExt;
+use kalshi_fast::{
+    KalshiAuth, KalshiEnvironment, KalshiError, KalshiWsLowLevelClient, WsChannelV2,
+    WsSubscriptionParamsV2, WsUpdateAction, WsUpdateSubscriptionParamsV2,
+};
+use rand::rngs::OsRng;
+use rsa::RsaPrivateKey;
+use rsa::pkcs8::{EncodePrivateKey, LineEnding};
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+use tokio::time::sleep;
+use tokio_tungstenite::accept_async;
+use tokio_tungstenite::tungstenite::Message;
+use url::Url;
+
+fn test_auth() -> KalshiAuth {
+    static TEST_PEM: OnceLock<String> = OnceLock::new();
+
+    let pem = TEST_PEM.get_or_init(|| {
+        let mut rng = OsRng;
+        let private_key = RsaPrivateKey::new(&mut rng, 2048).expect("generate test private key");
+        private_key
+            .to_pkcs8_pem(LineEnding::LF)
+            .expect("encode test private key")
+            .to_string()
+    });
+
+    KalshiAuth::from_pem_str("test-key-id", pem).expect("load auth from generated PEM")
+}
+
+fn test_env(addr: SocketAddr) -> KalshiEnvironment {
+    KalshiEnvironment {
+        rest_origin: Url::parse("http://127.0.0.1/").expect("url"),
+        ws_url: format!("ws://{addr}"),
+    }
+}
+
+async fn read_single_text_payload(listener: TcpListener) -> Value {
+    let (stream, _) = listener.accept().await.expect("accept tcp");
+    let mut ws = accept_async(stream).await.expect("accept websocket");
+
+    let frame = ws.next().await.expect("frame").expect("ok frame");
+    let text = match frame {
+        Message::Text(text) => text.to_string(),
+        other => panic!("expected text frame, got {other:?}"),
+    };
+
+    serde_json::from_str(&text).expect("valid json payload")
+}
+
+#[tokio::test]
+async fn low_level_subscribe_serializes_singular_market_ticker() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+
+    let server = tokio::spawn(async move {
+        let payload = read_single_text_payload(listener).await;
+        assert_eq!(payload["cmd"], json!("subscribe"));
+        assert_eq!(payload["params"]["channels"], json!(["ticker"]));
+        assert_eq!(payload["params"]["market_ticker"], json!("TEST"));
+        assert!(payload["params"].get("market_tickers").is_none());
+    });
+
+    let mut client = KalshiWsLowLevelClient::connect_authenticated(test_env(addr), test_auth())
+        .await
+        .expect("connect");
+    client
+        .subscribe_v2(WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::Ticker],
+            market_ticker: Some("TEST".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("subscribe");
+
+    server.await.expect("server");
+}
+
+#[tokio::test]
+async fn low_level_subscribe_orderbook_delta_serializes_plural_market_tickers() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+
+    let server = tokio::spawn(async move {
+        let payload = read_single_text_payload(listener).await;
+        assert_eq!(payload["cmd"], json!("subscribe"));
+        assert_eq!(payload["params"]["channels"], json!(["orderbook_delta"]));
+        assert_eq!(payload["params"]["market_tickers"], json!(["TEST"]));
+        assert_eq!(payload["params"]["send_initial_snapshot"], json!(true));
+        assert!(payload["params"].get("market_ticker").is_none());
+        assert!(payload["params"].get("market_id").is_none());
+        assert!(payload["params"].get("market_ids").is_none());
+    });
+
+    let mut client = KalshiWsLowLevelClient::connect_authenticated(test_env(addr), test_auth())
+        .await
+        .expect("connect");
+    client
+        .subscribe_v2(WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::OrderbookDelta],
+            market_tickers: Some(vec!["TEST".to_string()]),
+            send_initial_snapshot: Some(true),
+            ..Default::default()
+        })
+        .await
+        .expect("subscribe");
+
+    server.await.expect("server");
+}
+
+#[tokio::test]
+async fn low_level_update_subscription_serializes_skip_ticker_ack() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+
+    let server = tokio::spawn(async move {
+        let payload = read_single_text_payload(listener).await;
+        assert_eq!(payload["cmd"], json!("update_subscription"));
+        assert_eq!(payload["params"]["action"], json!("add_markets"));
+        assert_eq!(payload["params"]["sid"], json!(42));
+        assert_eq!(payload["params"]["market_tickers"], json!(["TEST", "ALT"]));
+        assert_eq!(payload["params"]["skip_ticker_ack"], json!(true));
+        assert!(payload["params"].get("sids").is_none());
+    });
+
+    let mut client = KalshiWsLowLevelClient::connect_authenticated(test_env(addr), test_auth())
+        .await
+        .expect("connect");
+    client
+        .update_subscription_v2(WsUpdateSubscriptionParamsV2 {
+            action: WsUpdateAction::AddMarkets,
+            sid: Some(42),
+            sids: None,
+            market_ticker: None,
+            market_tickers: Some(vec!["TEST".to_string(), "ALT".to_string()]),
+            market_id: None,
+            market_ids: None,
+            send_initial_snapshot: None,
+            skip_ticker_ack: Some(true),
+        })
+        .await
+        .expect("update subscription");
+
+    server.await.expect("server");
+}
+
+#[tokio::test]
+async fn low_level_subscribe_rejects_both_market_ticker_forms() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept tcp");
+        let _ws = accept_async(stream).await.expect("accept websocket");
+        sleep(Duration::from_millis(100)).await;
+    });
+
+    let mut client = KalshiWsLowLevelClient::connect_authenticated(test_env(addr), test_auth())
+        .await
+        .expect("connect");
+    let err = client
+        .subscribe_v2(WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::Ticker],
+            market_ticker: Some("TEST".to_string()),
+            market_tickers: Some(vec!["ALT".to_string()]),
+            ..Default::default()
+        })
+        .await
+        .expect_err("subscribe should fail");
+
+    assert!(matches!(
+        err,
+        KalshiError::InvalidParams(message)
+            if message.contains("market_ticker or market_tickers")
+    ));
+
+    server.await.expect("server");
+}

--- a/tests/ws_parsing.rs
+++ b/tests/ws_parsing.rs
@@ -1,8 +1,8 @@
 //! Unit tests for WebSocket message parsing.
 
 use kalshi_fast::{
-    WsCommunications, WsDataMessage, WsEnvelope, WsMarketLifecycleEventType, WsMessage, WsMsgType,
-    WsOrderGroupEventType, WsOrderbookDelta, WsTicker, YesNo,
+    WsCommunications, WsDataMessageV2, WsEnvelope, WsMarketLifecycleEventType, WsMessageV2,
+    WsMsgType, WsOrderGroupEventType, WsOrderbookDelta, WsTicker, YesNo,
 };
 use serde_json::Value;
 
@@ -35,7 +35,7 @@ fn ws_message_subscribed_parses() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Subscribed { id, sid } => {
+        WsMessageV2::Subscribed { id, sid } => {
             assert_eq!(id, Some(5));
             assert_eq!(sid, Some(99));
         }
@@ -57,7 +57,7 @@ fn ws_message_subscribed_parses_sid_from_msg() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Subscribed { id, sid } => {
+        WsMessageV2::Subscribed { id, sid } => {
             assert_eq!(id, Some(6));
             assert_eq!(sid, Some(321));
         }
@@ -80,7 +80,7 @@ fn ws_message_list_subscriptions_parses() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::ListSubscriptions { id, subscriptions } => {
+        WsMessageV2::ListSubscriptions { id, subscriptions } => {
             assert_eq!(id, Some(7));
             assert_eq!(subscriptions.len(), 1);
             assert_eq!(subscriptions[0].sid, 1);
@@ -104,18 +104,18 @@ fn ws_message_list_subscriptions_parses_from_ok_msg_array() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::ListSubscriptions { id, subscriptions } => {
+        WsMessageV2::ListSubscriptions { id, subscriptions } => {
             assert_eq!(id, Some(8));
             assert_eq!(subscriptions.len(), 2);
             assert_eq!(subscriptions[0].sid, 11);
             assert_eq!(
                 subscriptions[0].channel,
-                Some(kalshi_fast::WsChannel::Ticker)
+                Some(kalshi_fast::WsChannelV2::Ticker)
             );
             assert_eq!(subscriptions[1].sid, 12);
             assert_eq!(
                 subscriptions[1].channel,
-                Some(kalshi_fast::WsChannel::Trade)
+                Some(kalshi_fast::WsChannelV2::Trade)
             );
         }
         other => panic!("unexpected: {:?}", other),
@@ -133,7 +133,7 @@ fn ws_message_error_parses() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Error { id, error } => {
+        WsMessageV2::Error { id, error } => {
             assert_eq!(id, Some(9));
             assert_eq!(error.code, Some(9));
             assert_eq!(error.message.as_deref(), Some("Authentication required"));
@@ -149,28 +149,29 @@ fn ws_ticker_message_parses() {
         "msg": {
             "market_ticker": "INXD-25JAN10-T17900",
             "market_id": "abc123",
-            "price": 55,
-            "yes_bid": 54,
-            "yes_ask": 56,
             "price_dollars": "0.55",
             "yes_bid_dollars": "0.54",
             "yes_ask_dollars": "0.56",
-            "volume": 10000,
+            "yes_bid_size_fp": "10.00",
+            "yes_ask_size_fp": "12.00",
+            "last_trade_size_fp": "2.00",
             "volume_fp": "10000.00",
-            "open_interest": 5000,
             "open_interest_fp": "5000.00",
             "dollar_volume": 5500,
             "dollar_open_interest": 2750,
-            "ts": 1700000000000
+            "ts": 1700000000,
+            "ts_ms": 1700000000000,
+            "time": "2025-01-10T12:00:00Z"
         }
     }"#;
 
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::Ticker { msg, .. }) => {
+        WsMessageV2::Data(WsDataMessageV2::Ticker { msg, .. }) => {
             assert_eq!(msg.market_ticker, "INXD-25JAN10-T17900");
-            assert_eq!(msg.price, 55);
+            assert_eq!(msg.price_dollars, "0.55");
+            assert_eq!(msg.yes_bid_size_fp, "10.00");
         }
         other => panic!("unexpected: {:?}", other),
     }
@@ -182,20 +183,23 @@ fn ws_trade_message_parses() {
         "type": "trade",
         "msg": {
             "trade_id": "trade-1",
-            "ticker": "MKT-1",
-            "price": 55,
-            "count": 10,
+            "market_ticker": "MKT-1",
+            "yes_price_dollars": "0.55",
+            "no_price_dollars": "0.45",
+            "count_fp": "10.00",
             "taker_side": "yes",
-            "created_time": "2025-01-10T12:00:00Z"
+            "ts": 1700000000,
+            "ts_ms": 1700000000000
         }
     }"#;
 
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::Trade { msg, .. }) => {
+        WsMessageV2::Data(WsDataMessageV2::Trade { msg, .. }) => {
             assert_eq!(msg.trade_id, "trade-1");
-            assert_eq!(msg.ticker, "MKT-1");
+            assert_eq!(msg.market_ticker, "MKT-1");
+            assert_eq!(msg.count_fp, "10.00");
         }
         other => panic!("unexpected: {:?}", other),
     }
@@ -218,7 +222,7 @@ fn ws_orderbook_snapshot_deserializes() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::OrderbookSnapshot { msg, .. }) => {
+        WsMessageV2::Data(WsDataMessageV2::OrderbookSnapshot { msg, .. }) => {
             assert_eq!(msg.market_ticker, "INXD-25JAN10-T17900");
             assert_eq!(msg.yes.len(), 2);
         }
@@ -233,23 +237,23 @@ fn ws_orderbook_delta_deserializes() {
         "msg": {
             "market_ticker": "INXD-25JAN10-T17900",
             "market_id": "abc123",
-            "price": 55,
             "price_dollars": "0.55",
-            "delta": 50,
             "delta_fp": "50.00",
             "side": "yes",
             "client_order_id": "my-order-1",
             "subaccount": 0,
-            "ts": "2025-01-10T12:00:00Z"
+            "ts": "2025-01-10T12:00:00Z",
+            "ts_ms": 1700000000000
         }
     }"#;
 
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::OrderbookDelta { msg, .. }) => {
+        WsMessageV2::Data(WsDataMessageV2::OrderbookDelta { msg, .. }) => {
             assert_eq!(msg.market_ticker, "INXD-25JAN10-T17900");
-            assert_eq!(msg.delta, 50);
+            assert_eq!(msg.delta_fp, "50.00");
+            assert_eq!(msg.ts_ms, Some(1700000000000));
         }
         other => panic!("unexpected: {:?}", other),
     }
@@ -260,34 +264,31 @@ fn ws_fill_deserializes() {
     let json = r#"{
         "type": "fill",
         "msg": {
-            "fill_id": "fill-123",
             "trade_id": "trade-456",
             "order_id": "order-789",
             "client_order_id": "my-order",
-            "ticker": "INXD-25JAN10-T17900",
             "market_ticker": "INXD-25JAN10-T17900",
             "side": "yes",
             "action": "buy",
-            "count": 10,
             "count_fp": "10.00",
-            "yes_price": 55,
-            "no_price": 45,
-            "yes_price_fixed": "0.55",
-            "no_price_fixed": "0.45",
+            "yes_price_dollars": "0.55",
             "is_taker": true,
             "fee_cost": "0.05",
-            "created_time": "2025-01-10T12:00:00Z",
-            "subaccount_number": 1,
-            "ts": 1700000000000
+            "ts": 1700000000,
+            "ts_ms": 1700000000000,
+            "post_position_fp": "15.00",
+            "purchased_side": "yes",
+            "subaccount": 1
         }
     }"#;
 
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::Fill { msg, .. }) => {
-            assert_eq!(msg.fill_id, "fill-123");
+        WsMessageV2::Data(WsDataMessageV2::Fill { msg, .. }) => {
             assert_eq!(msg.trade_id, "trade-456");
+            assert_eq!(msg.market_ticker, "INXD-25JAN10-T17900");
+            assert_eq!(msg.post_position_fp, "15.00");
         }
         other => panic!("unexpected: {:?}", other),
     }
@@ -301,19 +302,19 @@ fn ws_envelope_parse_ticker_raw() {
         "msg": {
             "market_ticker": "TEST",
             "market_id": "abc",
-            "price": 50,
-            "yes_bid": 49,
-            "yes_ask": 51,
             "price_dollars": "0.50",
             "yes_bid_dollars": "0.49",
             "yes_ask_dollars": "0.51",
-            "volume": 1000,
+            "yes_bid_size_fp": "2.00",
+            "yes_ask_size_fp": "3.00",
+            "last_trade_size_fp": "1.00",
             "volume_fp": "1000.00",
-            "open_interest": 500,
             "open_interest_fp": "500.00",
             "dollar_volume": 500,
             "dollar_open_interest": 250,
-            "ts": 1700000000
+            "ts": 1700000000,
+            "ts_ms": 1700000000000,
+            "time": "2025-01-10T12:00:00Z"
         }
     }"#;
 
@@ -330,18 +331,17 @@ fn ws_orderbook_delta_raw() {
         "msg": {
             "market_ticker": "TEST",
             "market_id": "abc",
-            "price": 50,
             "price_dollars": "0.50",
-            "delta": 10,
             "delta_fp": "10.00",
-            "side": "yes"
+            "side": "yes",
+            "ts_ms": 1700000000000
         }
     }"#;
 
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let raw = env.msg_raw().unwrap();
     let msg: WsOrderbookDelta = serde_json::from_str(raw).unwrap();
-    assert_eq!(msg.delta, 10);
+    assert_eq!(msg.delta_fp, "10.00");
 }
 
 #[test]
@@ -366,7 +366,7 @@ fn ws_market_lifecycle_v2_message_parses() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::MarketLifecycleV2 { msg, .. }) => {
+        WsMessageV2::Data(WsDataMessageV2::MarketLifecycleV2 { msg, .. }) => {
             assert_eq!(msg.market_ticker, "MKT-1");
             assert_eq!(msg.event_type, Some(WsMarketLifecycleEventType::Created));
             assert_eq!(msg.open_ts, Some(1700000000));
@@ -405,7 +405,7 @@ fn ws_event_lifecycle_message_parses() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::EventLifecycle { msg, .. }) => {
+        WsMessageV2::Data(WsDataMessageV2::EventLifecycle { msg, .. }) => {
             assert_eq!(msg.event_ticker, "EVT-1");
             assert_eq!(msg.title.as_deref(), Some("Event title"));
             assert_eq!(msg.subtitle.as_deref(), Some("Event subtitle"));
@@ -437,7 +437,7 @@ fn ws_event_lifecycle_v2_alias_parses() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::EventLifecycle { msg, .. }) => {
+        WsMessageV2::Data(WsDataMessageV2::EventLifecycle { msg, .. }) => {
             assert_eq!(msg.event_ticker, "EVT-ALIAS");
         }
         other => panic!("unexpected: {:?}", other),
@@ -447,20 +447,25 @@ fn ws_event_lifecycle_v2_alias_parses() {
 #[test]
 fn ws_market_positions_message_parses() {
     let json = r#"{
-        "type": "market_positions",
+        "type": "market_position",
         "msg": {
-            "market_positions": [{"ticker":"MKT-1","position":1}],
-            "event_positions": [{"event_ticker":"EVT-1","position":2}]
+            "user_id": "user-1",
+            "market_ticker": "MKT-1",
+            "position_fp": "1.00",
+            "position_cost_dollars": "0.52",
+            "realized_pnl_dollars": "0.10",
+            "fees_paid_dollars": "0.01",
+            "position_fee_cost_dollars": "0.02",
+            "volume_fp": "10.00"
         }
     }"#;
 
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::MarketPositions { msg, .. }) => {
-            assert_eq!(msg.market_positions.len(), 1);
-            assert_eq!(msg.market_positions[0].ticker, "MKT-1");
-            assert_eq!(msg.event_positions[0].event_ticker, "EVT-1");
+        WsMessageV2::Data(WsDataMessageV2::MarketPosition { msg, .. }) => {
+            assert_eq!(msg.market_ticker, "MKT-1");
+            assert_eq!(msg.position_fp, "1.00");
         }
         other => panic!("unexpected: {:?}", other),
     }
@@ -484,7 +489,7 @@ fn ws_rfq_created_message_parses() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::Communications { msg, .. }) => match msg {
+        WsMessageV2::Data(WsDataMessageV2::Communications { msg, .. }) => match msg {
             WsCommunications::RfqCreated(rfq) => {
                 assert_eq!(rfq.id, "rfq_123");
                 assert_eq!(rfq.market_ticker, "FED-23DEC-T3.00");
@@ -514,7 +519,7 @@ fn ws_rfq_deleted_message_parses() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::Communications { msg, .. }) => match msg {
+        WsMessageV2::Data(WsDataMessageV2::Communications { msg, .. }) => match msg {
             WsCommunications::RfqDeleted(rfq) => {
                 assert_eq!(rfq.id, "rfq_124");
                 assert_eq!(rfq.creator_id, "creator");
@@ -545,7 +550,7 @@ fn ws_quote_created_message_parses() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::Communications { msg, .. }) => match msg {
+        WsMessageV2::Data(WsDataMessageV2::Communications { msg, .. }) => match msg {
             WsCommunications::QuoteCreated(quote) => {
                 assert_eq!(quote.quote_id, "q-1");
                 assert_eq!(quote.yes_bid, 50);
@@ -577,7 +582,7 @@ fn ws_quote_accepted_message_parses() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::Communications { msg, .. }) => match msg {
+        WsMessageV2::Data(WsDataMessageV2::Communications { msg, .. }) => match msg {
             WsCommunications::QuoteAccepted(quote) => {
                 assert_eq!(quote.quote_id, "q-2");
                 assert!(matches!(quote.accepted_side, Some(YesNo::Yes)));
@@ -608,7 +613,7 @@ fn ws_quote_executed_message_parses() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::Communications { msg, .. }) => match msg {
+        WsMessageV2::Data(WsDataMessageV2::Communications { msg, .. }) => match msg {
             WsCommunications::QuoteExecuted(quote) => {
                 assert_eq!(quote.quote_id, "q-3");
                 assert_eq!(quote.order_id, "order-1");
@@ -636,7 +641,7 @@ fn ws_multivariate_message_parses() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::Multivariate { msg, .. }) => {
+        WsMessageV2::Data(WsDataMessageV2::Multivariate { msg, .. }) => {
             assert_eq!(msg.collection_ticker, "COLL-1");
             assert!(matches!(msg.selected_markets[0].side, YesNo::Yes));
         }
@@ -654,7 +659,7 @@ fn ws_order_group_updates_message_parses() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::OrderGroupUpdates { msg, .. }) => {
+        WsMessageV2::Data(WsDataMessageV2::OrderGroupUpdates { msg, .. }) => {
             assert_eq!(msg.order_group_id, "og-1");
             assert!(matches!(
                 msg.event_type,
@@ -677,23 +682,28 @@ fn ws_user_order_message_parses() {
             "ticker": "INXD-26FEB14-T19000",
             "status": "resting",
             "side": "yes",
+            "is_yes": true,
             "yes_price_dollars": "0.5500",
             "fill_count_fp": "0.00",
             "remaining_count_fp": "10.00",
             "initial_count_fp": "10.00",
             "taker_fill_cost_dollars": "0.0000",
             "maker_fill_cost_dollars": "0.0000",
+            "taker_fees_dollars": "0.0000",
+            "maker_fees_dollars": "0.0000",
             "client_order_id": "abc-123",
-            "created_time": "2026-02-14T12:00:00Z"
+            "created_time": "2026-02-14T12:00:00Z",
+            "created_ts_ms": 1771070400000
         }
     }"#;
 
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::Data(WsDataMessage::UserOrder { sid, msg, .. }) => {
+        WsMessageV2::Data(WsDataMessageV2::UserOrder { sid, msg, .. }) => {
             assert_eq!(sid, Some(2));
             assert_eq!(msg.ticker, "INXD-26FEB14-T19000");
+            assert_eq!(msg.is_yes, Some(true));
             assert_eq!(msg.yes_price_dollars.as_deref(), Some("0.5500"));
             assert_eq!(msg.remaining_count_fp.as_deref(), Some("10.00"));
         }
@@ -714,7 +724,7 @@ fn ws_list_subscriptions_parses_from_subscriptions_field() {
     let env: WsEnvelope = serde_json::from_str(json).unwrap();
     let msg = env.into_message().unwrap();
     match msg {
-        WsMessage::ListSubscriptions { id, subscriptions } => {
+        WsMessageV2::ListSubscriptions { id, subscriptions } => {
             assert_eq!(id, Some(2));
             assert_eq!(subscriptions.len(), 1);
             assert_eq!(subscriptions[0].sid, 10);

--- a/tests/ws_public.rs
+++ b/tests/ws_public.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use kalshi_fast::{
-    KalshiWsLowLevelClient, WsChannel, WsDataMessage, WsMessage, WsSubscriptionParams,
+    KalshiWsLowLevelClient, WsChannelV2, WsDataMessageV2, WsMessageV2, WsSubscriptionParamsV2,
 };
 use std::time::Duration;
 
@@ -40,8 +40,8 @@ async fn test_ws_ticker_subscribe() {
     .expect("connection failed");
 
     let sub_id = ws
-        .subscribe(WsSubscriptionParams {
-            channels: vec![WsChannel::Ticker],
+        .subscribe_v2(WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::Ticker],
             ..Default::default()
         })
         .await
@@ -50,14 +50,16 @@ async fn test_ws_ticker_subscribe() {
     assert!(sub_id > 0);
 
     // Read first message (should be subscribed confirmation or ticker data)
-    let msg = tokio::time::timeout(Duration::from_secs(10), async { ws.next_message().await })
-        .await
-        .expect("timeout")
-        .expect("receive failed");
+    let msg = tokio::time::timeout(Duration::from_secs(10), async {
+        ws.next_message_v2().await
+    })
+    .await
+    .expect("timeout")
+    .expect("receive failed");
 
     match msg {
-        WsMessage::Subscribed { .. } => {}
-        WsMessage::Data(WsDataMessage::Ticker { .. }) => {}
+        WsMessageV2::Subscribed { .. } => {}
+        WsMessageV2::Data(WsDataMessageV2::Ticker { .. }) => {}
         other => panic!("unexpected message: {:?}", other),
     }
 }
@@ -80,8 +82,8 @@ async fn test_ws_private_channel_requires_auth_flag() {
 
     // Subscribing to private channel on authenticated connection should succeed
     let result = ws
-        .subscribe(WsSubscriptionParams {
-            channels: vec![WsChannel::Fill],
+        .subscribe_v2(WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::Fill],
             ..Default::default()
         })
         .await;
@@ -96,16 +98,16 @@ fn test_client_rejects_private_channel_without_auth() {
     // We can't actually test the unauthenticated connection since Kalshi
     // requires auth for all WebSocket connections
 
-    // Just verify that WsChannel::is_private returns true for private channels
-    assert!(WsChannel::Fill.is_private());
-    assert!(WsChannel::OrderbookDelta.is_private());
-    assert!(WsChannel::MarketPositions.is_private());
-    assert!(WsChannel::Communications.is_private());
-    assert!(WsChannel::OrderGroupUpdates.is_private());
+    // Just verify that WsChannelV2::is_private returns true for private channels
+    assert!(WsChannelV2::Fill.is_private());
+    assert!(WsChannelV2::OrderbookDelta.is_private());
+    assert!(WsChannelV2::MarketPositions.is_private());
+    assert!(WsChannelV2::Communications.is_private());
+    assert!(WsChannelV2::OrderGroupUpdates.is_private());
 
     // And false for public channels
-    assert!(!WsChannel::Ticker.is_private());
-    assert!(!WsChannel::Trade.is_private());
-    assert!(!WsChannel::MarketLifecycleV2.is_private());
-    assert!(!WsChannel::Multivariate.is_private());
+    assert!(!WsChannelV2::Ticker.is_private());
+    assert!(!WsChannelV2::Trade.is_private());
+    assert!(!WsChannelV2::MarketLifecycleV2.is_private());
+    assert!(!WsChannelV2::Multivariate.is_private());
 }


### PR DESCRIPTION
# Description

- Migrates the WebSocket and REST clients onto Kalshi's V2 APIs and bumps the crate to `0.4.0`.
  - Adds new REST data-retrieval methods with richer type support.
- Updates tests and examples to use `demo_client` / `demo_auth_client` helpers on the V2 surface.
- Tightens CI: drops the Python setup step and forces single-threaded live tests so rate-limited endpoints behave.
- Refreshes crate-level, README, and VERSIONING docs to reflect the V2 migration and spec-parity step.

# Test

- [ ] `cargo test`
- [ ] `cargo test --test ws_parsing --test ws_public --test ws_auth`
- [ ] `cargo build --examples`