### PR TITLE
[v0.4][3/n] refactor(types)!: tighten type contracts and finalize 0.4.0 changelog

### DIFF
--- a/.codex/skills/kalshi-refresh/SKILL.md
+++ b/.codex/skills/kalshi-refresh/SKILL.md
@@ -1,7 +1,7 @@
 # Kalshi Refresh
 
-Use this skill for recurring refreshes of `kalshi-fast-rs` against the current
-Kalshi docs and changelog.
+Use this repo-local skill for recurring refreshes of `kalshi-fast-rs` against
+Kalshi's current published docs and changelog.
 
 ## Read First
 
@@ -10,8 +10,11 @@ Before making changes, read:
 - `AGENTS.md`
 - `VERSIONING.md`
 - `CHANGELOG.md`
+- `Cargo.toml`
 - `README.md`
+- `docs/README.md`
 - `src/lib.rs`
+- `docs/spec-parity.md`
 
 ## Source Of Truth
 
@@ -22,52 +25,72 @@ Use these upstream documents as the source of truth:
 - `https://docs.kalshi.com/openapi.yaml`
 - `https://docs.kalshi.com/asyncapi.yaml`
 
-Use this local note file when there is repo-specific context worth preserving:
+Re-fetch these documents during every refresh. Do not rely on cached knowledge.
+Capture exact dates and spec versions from them when updating compatibility
+notes.
+
+Use this local note file only when there is repo-specific context worth
+preserving:
 
 - `docs/spec-parity.md`
 
 ## Workflow
 
-1. Read the current changelog RSS and identify new or upcoming changes since the latest release or `Unreleased` entry.
-2. Classify each relevant upstream change as breaking or non-breaking for:
+1. Read the active `Unreleased` entry in `CHANGELOG.md`, the current crate
+   version in `Cargo.toml`, and the most recent recorded compatibility tuple.
+2. Fetch the current changelog RSS, OpenAPI, and AsyncAPI. Record:
+   - docs snapshot date used for the refresh
+   - OpenAPI version
+   - AsyncAPI version
+   - latest changelog date validated by the refresh
+3. Identify upstream changes since the repo's last validated compatibility or
+   changelog coverage, not just since the last release tag.
+4. Classify each relevant upstream change as breaking or non-breaking for:
    - the upstream Kalshi contract
    - the public Rust API of this crate
-3. Check the live OpenAPI and AsyncAPI for schema drift relative to the current
-   code, tests, and docs.
-4. Update `docs/spec-parity.md` only for short human-facing notes about
-   distinctions or behaviors that are not obvious from the YAML alone.
-5. Search the codebase for deprecated endpoints, API shapes, fields, and examples that no longer match the current Kalshi docs.
-6. Update code, tests, docs, and examples so the crate does not keep stale deprecated shapes around unnecessarily.
-7. Prefer behavior and integration tests over generated parity artifacts when
-   the YAML specs do not fully define runtime behavior.
-8. Propose the crate version bump using `VERSIONING.md`:
+5. Check the live OpenAPI and AsyncAPI for schema drift relative to the current
+   code, tests, docs, and examples. Remove or update stale deprecated
+   endpoints, fields, enums, examples, and tests instead of carrying them
+   forward silently.
+6. Update `docs/spec-parity.md` only for durable human-facing notes about
+   distinctions or behaviors that are not obvious from the YAML alone. Do not
+   turn it into a raw diff dump.
+7. Update code, tests, docs, and examples so the crate reflects current
+   upstream behavior.
+8. Apply the crate version bump in `Cargo.toml` and `Cargo.lock` using
+   `VERSIONING.md`:
    - patch for Rust API non-breaking refreshes
    - minor for Rust API breaking changes
-9. Update `CHANGELOG.md`:
+9. Update the active `CHANGELOG.md` entry:
    - keep the active entry in normal changelog form
-   - include a `Compatibility` block
+   - fill the `Compatibility` block with exact upstream dates and versions
+   - add a `Breaking` section when downstream Rust code must change
    - use clear bullet prefixes like `[Rust API]`, `[Upstream]`, `[Docs]`, `[CI]`, or `[Tests]` where useful
-10. Update `README.md` and `src/lib.rs` if the public compatibility statement or release/versioning references changed.
-11. Run the relevant checks and summarize:
+10. Update `README.md`, `docs/README.md`, and `src/lib.rs` if compatibility
+    statements, examples, test guidance, or release/versioning references
+    changed.
+11. Run the relevant checks:
+    - `cargo fmt --check`
+    - `cargo test --all-targets`
+    - live tests only when credentials are available and the refresh needs live
+      validation:
+      - `cargo test --features live-tests --test rest_public`
+      - `cargo test --features live-tests --test rest_auth`
+      - `cargo test --features live-tests --test ws_public`
+      - `cargo test --features live-tests --test ws_auth`
+12. Summarize:
    - what changed upstream
    - whether the changes are breaking
-   - what version bump is proposed
-   - what code or docs were updated
+   - what compatibility tuple was validated
+   - what version bump was applied or proposed
+   - what code, docs, or tests were updated
    - any blockers or unresolved drift
 
 ## Expectations
 
 - Do not leave obviously stale deprecated fields or endpoints in public structs, examples, or tests without documenting why.
+- Do not leave `Compatibility` values as `pending` after a completed refresh
+  unless an upstream source was unavailable; state the blocker explicitly.
 - Prefer aligning the crate to the current Kalshi docs rather than preserving obsolete compatibility shims indefinitely.
 - Keep the changelog useful for humans. Policy belongs in `VERSIONING.md`; release notes belong in `CHANGELOG.md`.
-
-## Suggested Automation Prompt
-
-Use this skill and keep the recurring prompt short. Example:
-
-```md
-Use [$kalshi-refresh](</Users/swe/repos/kalshi-rs/.codex/skills/kalshi-refresh/SKILL.md>).
-Refresh the repo against the current Kalshi docs, classify new upstream changes
-as breaking or non-breaking, update stale deprecated API shapes, propose the
-appropriate version bump, and prepare the changelog/docs updates.
-```
+- Keep `docs/spec-parity.md` short and durable.

--- a/.codex/skills/kalshi-refresh/SKILL.md
+++ b/.codex/skills/kalshi-refresh/SKILL.md
@@ -1,3 +1,7 @@
+---
+name: kalshi-refresh
+description: Use this repo-local skill for recurring refreshes of `kalshi-fast-rs` against Kalshi's current published docs and changelog.
+---
 # Kalshi Refresh
 
 Use this repo-local skill for recurring refreshes of `kalshi-fast-rs` against

--- a/.codex/skills/kalshi-refresh/SKILL.md
+++ b/.codex/skills/kalshi-refresh/SKILL.md
@@ -56,6 +56,10 @@ preserving:
    code, tests, docs, and examples. Remove or update stale deprecated
    endpoints, fields, enums, examples, and tests instead of carrying them
    forward silently.
+   - if a field or response shape was removed from the live schema, remove it
+     from the public Rust API rather than preserving it as an optional field,
+     compatibility alias, or synthesized legacy view unless `docs/spec-parity.md`
+     documents an explicit exception.
 6. Update `docs/spec-parity.md` only for durable human-facing notes about
    distinctions or behaviors that are not obvious from the YAML alone. Do not
    turn it into a raw diff dump.
@@ -65,7 +69,12 @@ preserving:
    `VERSIONING.md`:
    - patch for Rust API non-breaking refreshes
    - minor for Rust API breaking changes
+   - this only applies if the current branch is version agnostic.
+   - always look at the current branch name. If there is a `vX.Y.Z` tag, then the version
+     should be `X.Y.Z`.
+   - in other words, only bump version when the branch is version agnostic.
 9. Update the active `CHANGELOG.md` entry:
+   - if the current branch name contains a `vX.Y.Z` tag, then update the matching entry.
    - keep the active entry in normal changelog form
    - fill the `Compatibility` block with exact upstream dates and versions
    - add a `Breaking` section when downstream Rust code must change
@@ -93,6 +102,9 @@ preserving:
 ## Expectations
 
 - Do not leave obviously stale deprecated fields or endpoints in public structs, examples, or tests without documenting why.
+- Do not preserve removed upstream schema fields by converting them to optional
+  Rust fields or by synthesizing removed response shapes unless an explicit
+  repo-level exception is documented.
 - Do not leave `Compatibility` values as `pending` after a completed refresh
   unless an upstream source was unavailable; state the blocker explicitly.
 - Prefer aligning the crate to the current Kalshi docs rather than preserving obsolete compatibility shims indefinitely.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,45 @@ For crate versioning policy and bump rules, see [`VERSIONING.md`](VERSIONING.md)
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-18
+
 ### Compatibility
 
-- Docs snapshot: pending
-- OpenAPI: pending
-- AsyncAPI: pending
-- Validated through changelog: pending
+- Docs snapshot: 2026-04-18
+- OpenAPI: 3.13.0
+- AsyncAPI: 2.0.0
+- Validated through changelog: 2026-04-16
+
+### Added
+
+- [Rust API] Added REST helpers for current Kalshi endpoints and aliases, including `get_market_orderbooks`, `get_trades_historical`, `get_fills_historical`, `get_live_data_by_milestone`, `get_game_stats`, and `get_market_candlesticks_historical`.
+- [Rust API] Added current OpenAPI fields used by the refreshed docs, including `occurrence_datetime` on event and market payloads, `series_ticker` on historical market filters, and fixed-point quote contract fields.
+- [Docs] Added `VERSIONING.md` plus repo guidance that points refresh work at the live Kalshi docs, changelog RSS, OpenAPI, and AsyncAPI documents instead of checked-in spec snapshots.
+
+### Changed
+
+- [Rust API] Migrated the WebSocket public surface to the current V2 contract, including `WsChannelV2`, `WsMessageV2`, `WsDataMessageV2`, `WsSubscriptionParamsV2`, and the `subscribe_v2` / `unsubscribe_v2` / `update_subscription_v2` / `start_reader_v2` / `next_event_v2` methods.
+- [Upstream] Updated docs, examples, and tests for Kalshi's current WebSocket handshake behavior, which now requires authenticated connections even when subscribing only to public channels.
+- [Rust API] Aligned authenticated REST response structs with the current OpenAPI fixed-point contract for `Order`, `Trade`, `Fill`, `Settlement`, `MarketPosition`, and `EventPosition`.
+- [Rust API] Aligned communications REST and WebSocket quote/RFQ payloads with the current fixed-point-only docs by removing stale integer compatibility fields and relying on `*_dollars` and `*_fp` fields.
+- [Upstream] Validated the current Kalshi docs snapshot against the changelog items covering historical `series_ticker` filtering, fixed-point response cleanup, millisecond WebSocket timestamps, and `occurrence_datetime` on market responses.
+- [Tests] Refreshed parsing fixtures to the current OpenAPI/AsyncAPI field sets, added coverage for `occurrence_datetime`, and added deterministic V2 WebSocket command-behavior coverage.
+- [Tests] Updated live integration coverage to use the filters and account-scope assumptions required by the current communications, queue-position, and FCM-only portfolio endpoints.
+
+### Removed
+
+- [Docs] Removed vendored OpenAPI/AsyncAPI snapshots, spec manifest artifacts, the parity generation script, and raw spec contract tests in favor of live upstream docs plus concise `docs/spec-parity.md` notes.
+- [Rust API] Removed stale REST compatibility fields and aliases that are no longer present in the current OpenAPI, including legacy fill/settlement fixed-point aliases.
+- [Rust API] Removed stale WebSocket fill aliases for `yes_price_fixed` and `no_price_fixed` so parsing follows the current AsyncAPI names.
+- [Rust API] Removed stale quote and RFQ integer compatibility fields from REST and WebSocket communications payloads.
+
+### Breaking
+
+- [Rust API] Downstream WebSocket code must migrate from the pre-V2 types and methods such as `WsChannel`, `WsMessage`, `WsDataMessage`, `subscribe`, `unsubscribe`, `update_subscription`, `start_reader`, and `next_event` to the V2 names and `*_v2` methods.
+- [Rust API] `KalshiWsClient::connect` and `KalshiWsLowLevelClient::connect` no longer provide an unauthenticated public-channel path; downstream code must use `connect_authenticated`, even for public subscriptions.
+- [Rust API] V2 subscription validation is stricter: `orderbook_delta` requires `market_ticker` or `market_tickers`, rejects `market_id` and `market_ids`, and enforces exclusive market-target fields on subscribe and update commands.
+- [Rust API] Downstream code must update authenticated REST response field access to the current spec names such as `fill_count_fp`, `remaining_count_fp`, `initial_count_fp`, `last_update_time`, `subaccount_number`, `total_traded_dollars`, `market_exposure_dollars`, `total_cost_dollars`, and `total_cost_shares_fp`.
+- [Rust API] Legacy integer/count response fields and compatibility aliases previously accepted by `Order`, `Trade`, `Fill`, `Settlement`, `MarketPosition`, and `EventPosition` are no longer exposed by the public Rust types.
 
 ## [0.3.0] - 2026-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ Kalshi docs snapshot tracked by that release.
 
 For crate versioning policy and bump rules, see [`VERSIONING.md`](VERSIONING.md).
 
-## [Unreleased]
 
 ## [0.4.0] - 2026-04-18
 
@@ -26,13 +25,15 @@ For crate versioning policy and bump rules, see [`VERSIONING.md`](VERSIONING.md)
 
 ### Changed
 
+- [Rust API] Restored `GetOrderQueuePositionsParams` to the current OpenAPI behavior by allowing unfiltered queue-position requests.
 - [Rust API] Migrated the WebSocket public surface to the current V2 contract, including `WsChannelV2`, `WsMessageV2`, `WsDataMessageV2`, `WsSubscriptionParamsV2`, and the `subscribe_v2` / `unsubscribe_v2` / `update_subscription_v2` / `start_reader_v2` / `next_event_v2` methods.
-- [Upstream] Updated docs, examples, and tests for Kalshi's current WebSocket handshake behavior, which now requires authenticated connections even when subscribing only to public channels.
 - [Rust API] Aligned authenticated REST response structs with the current OpenAPI fixed-point contract for `Order`, `Trade`, `Fill`, `Settlement`, `MarketPosition`, and `EventPosition`.
 - [Rust API] Aligned communications REST and WebSocket quote/RFQ payloads with the current fixed-point-only docs by removing stale integer compatibility fields and relying on `*_dollars` and `*_fp` fields.
 - [Upstream] Validated the current Kalshi docs snapshot against the changelog items covering historical `series_ticker` filtering, fixed-point response cleanup, millisecond WebSocket timestamps, and `occurrence_datetime` on market responses.
 - [Tests] Refreshed parsing fixtures to the current OpenAPI/AsyncAPI field sets, added coverage for `occurrence_datetime`, and added deterministic V2 WebSocket command-behavior coverage.
 - [Tests] Updated live integration coverage to use the filters and account-scope assumptions required by the current communications, queue-position, and FCM-only portfolio endpoints.
+- [Upstream] Updated docs, examples, and tests for Kalshi's current WebSocket handshake behavior, which now requires authenticated connections even when subscribing only to public channels.
+- [Docs] Tightened the refresh workflow to remove upstream-removed schema fields and response shapes from the public Rust API instead of preserving compatibility shims by default.
 
 ### Removed
 
@@ -40,6 +41,8 @@ For crate versioning policy and bump rules, see [`VERSIONING.md`](VERSIONING.md)
 - [Rust API] Removed stale REST compatibility fields and aliases that are no longer present in the current OpenAPI, including legacy fill/settlement fixed-point aliases.
 - [Rust API] Removed stale WebSocket fill aliases for `yes_price_fixed` and `no_price_fixed` so parsing follows the current AsyncAPI names.
 - [Rust API] Removed stale quote and RFQ integer compatibility fields from REST and WebSocket communications payloads.
+- [Rust API] Removed stale WebSocket compatibility fields and shapes from `WsTicker`, `WsTrade`, `WsOrderbookSnapshot`, `WsOrderbookDelta`, and `WsFill`; downstream consumers must use the current `*_dollars` and `*_fp` fields from the live AsyncAPI contract.
+- [Rust API] Removed the stale `GetMarketOrderbookResponse.orderbook` compatibility view and its synthesized integer orderbook shape; the current OpenAPI response is `orderbook_fp` only.
 
 ### Breaking
 
@@ -48,6 +51,8 @@ For crate versioning policy and bump rules, see [`VERSIONING.md`](VERSIONING.md)
 - [Rust API] V2 subscription validation is stricter: `orderbook_delta` requires `market_ticker` or `market_tickers`, rejects `market_id` and `market_ids`, and enforces exclusive market-target fields on subscribe and update commands.
 - [Rust API] Downstream code must update authenticated REST response field access to the current spec names such as `fill_count_fp`, `remaining_count_fp`, `initial_count_fp`, `last_update_time`, `subaccount_number`, `total_traded_dollars`, `market_exposure_dollars`, `total_cost_dollars`, and `total_cost_shares_fp`.
 - [Rust API] Legacy integer/count response fields and compatibility aliases previously accepted by `Order`, `Trade`, `Fill`, `Settlement`, `MarketPosition`, and `EventPosition` are no longer exposed by the public Rust types.
+- [Rust API] Downstream WebSocket code can no longer access removed compatibility fields such as `price`, `yes_bid`, `yes_ask`, `volume`, `open_interest`, `count`, `yes_price`, `no_price`, `delta`, `no_price_dollars`, or the legacy integer orderbook snapshot levels on current V2 message types.
+- [Rust API] Downstream REST code must read `GetMarketOrderbookResponse.orderbook_fp` directly; the legacy `orderbook` field has been removed.
 
 ## [0.3.0] - 2026-03-05
 

--- a/examples/orderbook_stream.rs
+++ b/examples/orderbook_stream.rs
@@ -133,10 +133,10 @@ async fn main() -> anyhow::Result<()> {
             WsEvent::Message(msg) => match msg {
                 WsMessageV2::Data(WsDataMessageV2::OrderbookSnapshot { msg, seq, .. }) => {
                     println!(
-                        "[SNAPSHOT] {} | yes={} no={} | seq={:?}",
+                        "[SNAPSHOT] {} | yes_fp={} no_fp={} | seq={:?}",
                         msg.market_ticker,
-                        msg.yes.len(),
-                        msg.no.len(),
+                        msg.yes_dollars_fp.len(),
+                        msg.no_dollars_fp.len(),
                         seq
                     );
                 }

--- a/src/rest/client.rs
+++ b/src/rest/client.rs
@@ -770,6 +770,46 @@ impl KalshiRestClient {
         }
     }
 
+    fn event_forecast_percentile_history_query(
+        params: &GetEventForecastPercentileHistoryParams,
+    ) -> Vec<(String, String)> {
+        let mut query = Vec::with_capacity(params.percentiles.len() + 3);
+        for percentile in &params.percentiles {
+            query.push(("percentiles".to_string(), percentile.to_string()));
+        }
+        query.push(("start_ts".to_string(), params.start_ts.to_string()));
+        query.push(("end_ts".to_string(), params.end_ts.to_string()));
+        query.push((
+            "period_interval".to_string(),
+            params.period_interval.to_string(),
+        ));
+        query
+    }
+
+    fn structured_targets_query(params: &GetStructuredTargetsParams) -> Vec<(String, String)> {
+        let mut query = Vec::new();
+
+        if let Some(ids) = &params.ids {
+            for id in ids {
+                query.push(("ids".to_string(), id.clone()));
+            }
+        }
+        if let Some(target_type) = &params.target_type {
+            query.push(("type".to_string(), target_type.clone()));
+        }
+        if let Some(competition) = &params.competition {
+            query.push(("competition".to_string(), competition.clone()));
+        }
+        if let Some(page_size) = params.page_size {
+            query.push(("page_size".to_string(), page_size.to_string()));
+        }
+        if let Some(cursor) = &params.cursor {
+            query.push(("cursor".to_string(), cursor.clone()));
+        }
+
+        query
+    }
+
     // -----------------------------------------------
     // Series
     // -----------------------------------------------
@@ -1765,7 +1805,8 @@ impl KalshiRestClient {
         let path = Self::full_path(&format!(
             "/series/{series_ticker}/events/{ticker}/forecast_percentile_history"
         ));
-        self.send(Method::GET, &path, Some(&params), Option::<&()>::None, true)
+        let query = Self::event_forecast_percentile_history_query(&params);
+        self.send(Method::GET, &path, Some(&query), Option::<&()>::None, true)
             .await
     }
 
@@ -1774,14 +1815,9 @@ impl KalshiRestClient {
         params: GetStructuredTargetsParams,
     ) -> Result<GetStructuredTargetsResponse, KalshiError> {
         let path = Self::full_path("/structured_targets");
-        self.send(
-            Method::GET,
-            &path,
-            Some(&params),
-            Option::<&()>::None,
-            false,
-        )
-        .await
+        let query = Self::structured_targets_query(&params);
+        self.send(Method::GET, &path, Some(&query), Option::<&()>::None, false)
+            .await
     }
 
     pub async fn get_structured_target(
@@ -1957,6 +1993,7 @@ impl KalshiRestClient {
         &self,
         params: GetOrderQueuePositionsParams,
     ) -> Result<GetOrderQueuePositionsResponse, KalshiError> {
+        params.validate()?;
         let path = Self::full_path("/portfolio/orders/queue_positions");
         self.send(Method::GET, &path, Some(&params), Option::<&()>::None, true)
             .await

--- a/src/rest/types.rs
+++ b/src/rest/types.rs
@@ -848,24 +848,11 @@ pub struct GetMarketOrderbooksResponse {
 pub struct Trade {
     pub trade_id: String,
     pub ticker: String,
-    #[serde(default)]
-    pub price: Option<f64>,
-    #[serde(default)]
-    pub count: Option<i64>,
-    #[serde(default)]
-    pub count_fp: Option<String>,
-    #[serde(default)]
-    pub yes_price: Option<i64>,
-    #[serde(default)]
-    pub no_price: Option<i64>,
-    #[serde(default)]
-    pub yes_price_dollars: Option<FixedPointDollars>,
-    #[serde(default)]
-    pub no_price_dollars: Option<FixedPointDollars>,
-    #[serde(default)]
-    pub taker_side: Option<TradeTakerSide>,
-    #[serde(default)]
-    pub created_time: Option<String>,
+    pub count_fp: FixedPointCount,
+    pub yes_price_dollars: FixedPointDollars,
+    pub no_price_dollars: FixedPointDollars,
+    pub taker_side: TradeTakerSide,
+    pub created_time: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -1082,47 +1069,24 @@ impl GetPositionsParams {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MarketPosition {
     pub ticker: String,
+    pub total_traded_dollars: FixedPointDollars,
+    pub position_fp: FixedPointCount,
+    pub market_exposure_dollars: FixedPointDollars,
+    pub realized_pnl_dollars: FixedPointDollars,
     #[serde(default)]
-    pub position: Option<i64>,
-    #[serde(default)]
-    pub position_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub fees_paid: Option<i64>,
-    #[serde(default)]
-    pub fees_paid_fp: Option<FixedPointDollars>,
-    #[serde(default)]
-    pub resting_orders: Option<i64>,
-    #[serde(default)]
-    pub resting_orders_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub total_traded: Option<i64>,
-    #[serde(default)]
-    pub total_traded_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub subaccount: Option<u32>,
+    pub resting_orders_count: Option<i32>,
+    pub fees_paid_dollars: FixedPointDollars,
+    pub last_updated_ts: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct EventPosition {
     pub event_ticker: String,
-    #[serde(default)]
-    pub position: Option<i64>,
-    #[serde(default)]
-    pub position_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub fees_paid: Option<i64>,
-    #[serde(default)]
-    pub fees_paid_fp: Option<FixedPointDollars>,
-    #[serde(default)]
-    pub resting_orders: Option<i64>,
-    #[serde(default)]
-    pub resting_orders_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub total_traded: Option<i64>,
-    #[serde(default)]
-    pub total_traded_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub subaccount: Option<u32>,
+    pub total_cost_dollars: FixedPointDollars,
+    pub total_cost_shares_fp: FixedPointCount,
+    pub event_exposure_dollars: FixedPointDollars,
+    pub realized_pnl_dollars: FixedPointDollars,
+    pub fees_paid_dollars: FixedPointDollars,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1211,61 +1175,37 @@ impl GetOrdersParams {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Order {
     pub order_id: String,
+    pub user_id: String,
+    pub client_order_id: String,
     pub ticker: String,
+    pub side: YesNo,
+    pub action: BuySell,
+    #[serde(rename = "type")]
+    pub order_type: OrderType,
+    pub status: OrderStatus,
+    pub yes_price_dollars: FixedPointDollars,
+    pub no_price_dollars: FixedPointDollars,
+    pub fill_count_fp: FixedPointCount,
+    pub remaining_count_fp: FixedPointCount,
+    pub initial_count_fp: FixedPointCount,
+    pub taker_fill_cost_dollars: FixedPointDollars,
+    pub maker_fill_cost_dollars: FixedPointDollars,
+    pub taker_fees_dollars: FixedPointDollars,
+    pub maker_fees_dollars: FixedPointDollars,
     #[serde(default)]
-    pub status: Option<OrderStatus>,
-    #[serde(default)]
-    pub side: Option<YesNo>,
-    #[serde(default)]
-    pub action: Option<BuySell>,
-    #[serde(default)]
-    pub count: Option<i64>,
-    #[serde(default)]
-    pub count_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub remaining_count: Option<i64>,
-    #[serde(default)]
-    pub remaining_count_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub filled_count: Option<i64>,
-    #[serde(default)]
-    pub filled_count_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub yes_price: Option<i64>,
-    #[serde(default)]
-    pub no_price: Option<i64>,
-    #[serde(default)]
-    #[serde(alias = "yes_price_fixed")]
-    pub yes_price_dollars: Option<FixedPointDollars>,
-    #[serde(default)]
-    #[serde(alias = "no_price_fixed")]
-    pub no_price_dollars: Option<FixedPointDollars>,
+    pub expiration_time: Option<String>,
     #[serde(default)]
     pub created_time: Option<String>,
     #[serde(default)]
-    pub updated_time: Option<String>,
-    #[serde(default)]
-    pub client_order_id: Option<String>,
+    pub last_update_time: Option<String>,
     #[serde(default)]
     pub order_group_id: Option<String>,
-    #[serde(default, rename = "type", alias = "order_type")]
-    pub order_type: Option<OrderType>,
-    #[serde(default)]
-    pub time_in_force: Option<TimeInForce>,
-    #[serde(default)]
-    pub reduce_only: Option<bool>,
-    #[serde(default)]
-    pub post_only: Option<bool>,
     #[serde(default)]
     pub cancel_order_on_pause: Option<bool>,
     #[serde(default)]
     pub self_trade_prevention_type: Option<SelfTradePreventionType>,
-    #[serde(default)]
-    pub subaccount: Option<u32>,
-    #[serde(default)]
-    pub fees_paid: Option<i64>,
-    #[serde(default)]
-    pub fees_paid_fp: Option<FixedPointDollars>,
+    #[serde(default, rename = "subaccount_number")]
+    pub subaccount_number: Option<u32>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1446,34 +1386,20 @@ pub struct Fill {
     pub order_id: String,
     pub trade_id: String,
     pub ticker: String,
-    #[serde(default)]
-    pub market_ticker: Option<String>,
-    #[serde(default)]
-    pub price: Option<i64>,
-    #[serde(default)]
-    pub count: Option<i64>,
-    #[serde(default)]
-    pub count_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub yes_price: Option<i64>,
-    #[serde(default)]
-    pub no_price: Option<i64>,
-    #[serde(default, alias = "yes_price_fixed")]
-    pub yes_price_dollars: Option<FixedPointDollars>,
-    #[serde(default, alias = "no_price_fixed")]
-    pub no_price_dollars: Option<FixedPointDollars>,
-    #[serde(default)]
-    pub side: Option<YesNo>,
-    #[serde(default)]
-    pub action: Option<BuySell>,
-    #[serde(default)]
-    pub is_taker: Option<bool>,
-    #[serde(default)]
-    pub fee_cost: Option<FixedPointDollars>,
+    pub market_ticker: String,
+    pub side: YesNo,
+    pub action: BuySell,
+    pub count_fp: FixedPointCount,
+    pub yes_price_dollars: FixedPointDollars,
+    pub no_price_dollars: FixedPointDollars,
+    pub is_taker: bool,
+    pub fee_cost: FixedPointDollars,
     #[serde(default)]
     pub created_time: Option<String>,
     #[serde(default)]
     pub subaccount_number: Option<u32>,
+    #[serde(default)]
+    pub ts: Option<i64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -1506,36 +1432,18 @@ pub struct GetFillsResponse {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Settlement {
-    pub settlement_id: String,
     pub ticker: String,
+    pub event_ticker: String,
+    pub market_result: String,
+    pub yes_count_fp: FixedPointCount,
+    pub yes_total_cost_dollars: FixedPointDollars,
+    pub no_count_fp: FixedPointCount,
+    pub no_total_cost_dollars: FixedPointDollars,
+    pub revenue: i64,
+    pub settled_time: String,
+    pub fee_cost: FixedPointDollars,
     #[serde(default)]
-    pub market_ticker: Option<String>,
-    #[serde(default)]
-    pub event_ticker: Option<String>,
-    #[serde(default)]
-    pub market_result: Option<String>,
-    #[serde(default)]
-    pub yes_count: Option<i64>,
-    #[serde(default)]
-    pub yes_count_fp: Option<FixedPointCount>,
-    #[serde(default, alias = "yes_total_cost")]
-    pub yes_total_cost_dollars: Option<FixedPointDollars>,
-    #[serde(default)]
-    pub no_count: Option<i64>,
-    #[serde(default)]
-    pub no_count_fp: Option<FixedPointCount>,
-    #[serde(default, alias = "no_total_cost")]
-    pub no_total_cost_dollars: Option<FixedPointDollars>,
-    #[serde(default)]
-    pub revenue: Option<FixedPointDollars>,
-    #[serde(default)]
-    pub settled_time: Option<String>,
-    #[serde(default)]
-    pub fee_cost: Option<FixedPointDollars>,
-    #[serde(default)]
-    pub value: Option<FixedPointDollars>,
-    #[serde(default)]
-    pub created_time: Option<String>,
+    pub value: Option<i64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -1703,13 +1611,9 @@ pub struct Quote {
     pub id: String,
     pub rfq_id: String,
     pub creator_id: String,
-    #[serde(default)]
-    pub rfq_creator_id: Option<String>,
+    pub rfq_creator_id: String,
     pub market_ticker: String,
-    pub contracts: i64,
     pub contracts_fp: FixedPointCount,
-    pub yes_bid: i64,
-    pub no_bid: i64,
     pub yes_bid_dollars: FixedPointDollars,
     pub no_bid_dollars: FixedPointDollars,
     pub created_ts: String,
@@ -1734,8 +1638,6 @@ pub struct Quote {
     #[serde(default)]
     pub rfq_creator_user_id: Option<String>,
     #[serde(default)]
-    pub rfq_target_cost_centi_cents: Option<i64>,
-    #[serde(default)]
     pub rfq_target_cost_dollars: Option<FixedPointDollars>,
     #[serde(default)]
     pub rfq_creator_order_id: Option<String>,
@@ -1754,10 +1656,7 @@ pub struct RFQ {
     pub id: String,
     pub creator_id: String,
     pub market_ticker: String,
-    pub contracts: i64,
     pub contracts_fp: FixedPointCount,
-    #[serde(default)]
-    pub target_cost_centi_cents: Option<i64>,
     #[serde(default)]
     pub target_cost_dollars: Option<FixedPointDollars>,
     pub status: String,
@@ -2465,6 +2364,19 @@ pub struct GetOrderQueuePositionsParams {
     pub subaccount: Option<u32>,
 }
 
+impl GetOrderQueuePositionsParams {
+    pub fn validate(&self) -> Result<(), KalshiError> {
+        if self.market_tickers.is_none() && self.event_ticker.is_none() {
+            return Err(KalshiError::InvalidParams(
+                "GET /portfolio/orders/queue_positions: market_tickers or event_ticker is required"
+                    .to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GetOrderQueuePositionsResponse {
     #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
@@ -2680,6 +2592,7 @@ pub struct PercentilePoint {
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct GetStructuredTargetsParams {
+    pub ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
     pub target_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/rest/types.rs
+++ b/src/rest/types.rs
@@ -5,7 +5,7 @@ use crate::types::{
     SelfTradePreventionType, TimeInForce, TradeTakerSide, YesNo, deserialize_null_as_empty_vec,
     deserialize_string_or_number, serialize_csv_opt,
 };
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::fmt;
 
@@ -788,22 +788,6 @@ pub struct GetMarketResponse {
 /// --- Orderbook ---
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
-pub struct Orderbook {
-    /// Price levels: (price_cents, quantity)
-    #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
-    pub yes: Vec<(i64, i64)>,
-    /// Price levels: (price_cents, quantity)
-    #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
-    pub no: Vec<(i64, i64)>,
-    /// Price levels: (price_dollars, quantity)
-    #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
-    pub yes_dollars: Vec<(FixedPointDollars, i64)>,
-    /// Price levels: (price_dollars, quantity)
-    #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
-    pub no_dollars: Vec<(FixedPointDollars, i64)>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct OrderbookFp {
     /// Price levels: (price_dollars, quantity_fp)
     #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
@@ -819,9 +803,8 @@ pub struct GetMarketOrderbookParams {
     pub depth: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GetMarketOrderbookResponse {
-    pub orderbook: Orderbook,
     pub orderbook_fp: OrderbookFp,
 }
 
@@ -2366,13 +2349,6 @@ pub struct GetOrderQueuePositionsParams {
 
 impl GetOrderQueuePositionsParams {
     pub fn validate(&self) -> Result<(), KalshiError> {
-        if self.market_tickers.is_none() && self.event_ticker.is_none() {
-            return Err(KalshiError::InvalidParams(
-                "GET /portfolio/orders/queue_positions: market_tickers or event_ticker is required"
-                    .to_string(),
-            ));
-        }
-
         Ok(())
     }
 }
@@ -2652,86 +2628,4 @@ pub struct SubaccountNettingConfig {
 pub struct GetSubaccountNettingResponse {
     #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
     pub netting_configs: Vec<SubaccountNettingConfig>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GetMarketOrderbookResponseWire {
-    #[serde(default)]
-    orderbook: Option<Orderbook>,
-    #[serde(default)]
-    orderbook_fp: Option<OrderbookFp>,
-}
-
-fn dollars_to_cents(value: &str) -> Option<i64> {
-    let (whole, frac) = value.split_once('.').unwrap_or((value, "0"));
-    let mut cents = frac.chars().take(2).collect::<String>();
-    while cents.len() < 2 {
-        cents.push('0');
-    }
-    Some(whole.parse::<i64>().ok()? * 100 + cents.parse::<i64>().ok()?)
-}
-
-fn fixed_point_count_to_i64(value: &str) -> Option<i64> {
-    value.split('.').next()?.parse::<i64>().ok()
-}
-
-fn synthesize_orderbook_from_fp(orderbook_fp: &OrderbookFp) -> Orderbook {
-    let convert = |levels: &[(FixedPointDollars, String)]| {
-        levels
-            .iter()
-            .filter_map(|(price, count)| {
-                Some((dollars_to_cents(price)?, fixed_point_count_to_i64(count)?))
-            })
-            .collect::<Vec<_>>()
-    };
-
-    Orderbook {
-        yes: convert(&orderbook_fp.yes_dollars),
-        no: convert(&orderbook_fp.no_dollars),
-        yes_dollars: orderbook_fp
-            .yes_dollars
-            .iter()
-            .filter_map(|(price, count)| Some((price.clone(), fixed_point_count_to_i64(count)?)))
-            .collect(),
-        no_dollars: orderbook_fp
-            .no_dollars
-            .iter()
-            .filter_map(|(price, count)| Some((price.clone(), fixed_point_count_to_i64(count)?)))
-            .collect(),
-    }
-}
-
-fn synthesize_orderbook_fp(orderbook: &Orderbook) -> OrderbookFp {
-    let convert = |levels: &[(FixedPointDollars, i64)]| {
-        levels
-            .iter()
-            .map(|(price, count)| (price.clone(), format!("{count}.00")))
-            .collect::<Vec<_>>()
-    };
-
-    OrderbookFp {
-        yes_dollars: convert(&orderbook.yes_dollars),
-        no_dollars: convert(&orderbook.no_dollars),
-    }
-}
-
-impl<'de> Deserialize<'de> for GetMarketOrderbookResponse {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let wire = GetMarketOrderbookResponseWire::deserialize(deserializer)?;
-        let orderbook_fp = wire
-            .orderbook_fp
-            .or_else(|| wire.orderbook.as_ref().map(synthesize_orderbook_fp))
-            .unwrap_or_default();
-        let orderbook = wire
-            .orderbook
-            .unwrap_or_else(|| synthesize_orderbook_from_fp(&orderbook_fp));
-
-        Ok(Self {
-            orderbook,
-            orderbook_fp,
-        })
-    }
 }

--- a/src/ws/types.rs
+++ b/src/ws/types.rs
@@ -313,23 +313,13 @@ pub struct WsSubscriptionInfo {
 pub struct WsTicker {
     pub market_ticker: String,
     pub market_id: String,
-    #[serde(default)]
-    pub price: i64,
-    #[serde(default)]
-    pub yes_bid: i64,
-    #[serde(default)]
-    pub yes_ask: i64,
     pub price_dollars: String,
     pub yes_bid_dollars: String,
     pub yes_ask_dollars: String,
     pub yes_bid_size_fp: String,
     pub yes_ask_size_fp: String,
     pub last_trade_size_fp: String,
-    #[serde(default)]
-    pub volume: i64,
     pub volume_fp: String,
-    #[serde(default)]
-    pub open_interest: i64,
     pub open_interest_fp: String,
     pub dollar_volume: i64,
     pub dollar_open_interest: i64,
@@ -344,15 +334,7 @@ pub struct WsTrade {
     pub trade_id: String,
     #[serde(alias = "ticker")]
     pub market_ticker: String,
-    #[serde(default)]
-    pub price: Option<i64>,
-    #[serde(default)]
-    pub count: Option<i64>,
     pub count_fp: String,
-    #[serde(default)]
-    pub yes_price: Option<i64>,
-    #[serde(default)]
-    pub no_price: Option<i64>,
     pub yes_price_dollars: String,
     pub no_price_dollars: String,
     pub taker_side: TradeTakerSide,
@@ -367,18 +349,6 @@ pub struct WsTrade {
 pub struct WsOrderbookSnapshot {
     pub market_ticker: String,
     pub market_id: String,
-    /// Price levels: (price_cents, quantity)
-    #[serde(default)]
-    pub yes: Vec<(i64, i64)>,
-    /// Price levels: (price_cents, quantity)
-    #[serde(default)]
-    pub no: Vec<(i64, i64)>,
-    /// Price levels: (price_dollars, quantity)
-    #[serde(default)]
-    pub yes_dollars: Vec<(String, i64)>,
-    /// Price levels: (price_dollars, quantity)
-    #[serde(default)]
-    pub no_dollars: Vec<(String, i64)>,
     /// Price levels: (price_dollars, quantity_fp) - fully fixed-point
     #[serde(default)]
     pub yes_dollars_fp: Vec<(String, String)>,
@@ -392,11 +362,7 @@ pub struct WsOrderbookSnapshot {
 pub struct WsOrderbookDelta {
     pub market_ticker: String,
     pub market_id: String,
-    #[serde(default)]
-    pub price: i64,
     pub price_dollars: String,
-    #[serde(default)]
-    pub delta: i64,
     pub delta_fp: String,
     pub side: YesNo,
     #[serde(default)]
@@ -420,16 +386,8 @@ pub struct WsFill {
     pub market_ticker: String,
     pub side: YesNo,
     pub action: BuySell,
-    #[serde(default)]
-    pub count: i64,
     pub count_fp: String,
-    #[serde(default)]
-    pub yes_price: i64,
-    #[serde(default)]
-    pub no_price: i64,
     pub yes_price_dollars: String,
-    #[serde(default)]
-    pub no_price_dollars: Option<String>,
     pub is_taker: bool,
     pub fee_cost: String,
     pub ts: i64,
@@ -878,12 +836,6 @@ pub struct WsTickerRef<'a> {
     pub market_ticker: Cow<'a, str>,
     #[serde(borrow)]
     pub market_id: Cow<'a, str>,
-    #[serde(default)]
-    pub price: i64,
-    #[serde(default)]
-    pub yes_bid: i64,
-    #[serde(default)]
-    pub yes_ask: i64,
     #[serde(borrow)]
     pub price_dollars: Cow<'a, str>,
     #[serde(borrow)]
@@ -896,12 +848,8 @@ pub struct WsTickerRef<'a> {
     pub yes_ask_size_fp: Cow<'a, str>,
     #[serde(borrow)]
     pub last_trade_size_fp: Cow<'a, str>,
-    #[serde(default)]
-    pub volume: i64,
     #[serde(borrow)]
     pub volume_fp: Cow<'a, str>,
-    #[serde(default)]
-    pub open_interest: i64,
     #[serde(borrow)]
     pub open_interest_fp: Cow<'a, str>,
     pub dollar_volume: i64,
@@ -917,18 +865,13 @@ impl<'a> WsTickerRef<'a> {
         WsTicker {
             market_ticker: self.market_ticker.into_owned(),
             market_id: self.market_id.into_owned(),
-            price: self.price,
-            yes_bid: self.yes_bid,
-            yes_ask: self.yes_ask,
             price_dollars: self.price_dollars.into_owned(),
             yes_bid_dollars: self.yes_bid_dollars.into_owned(),
             yes_ask_dollars: self.yes_ask_dollars.into_owned(),
             yes_bid_size_fp: self.yes_bid_size_fp.into_owned(),
             yes_ask_size_fp: self.yes_ask_size_fp.into_owned(),
             last_trade_size_fp: self.last_trade_size_fp.into_owned(),
-            volume: self.volume,
             volume_fp: self.volume_fp.into_owned(),
-            open_interest: self.open_interest,
             open_interest_fp: self.open_interest_fp.into_owned(),
             dollar_volume: self.dollar_volume,
             dollar_open_interest: self.dollar_open_interest,
@@ -946,16 +889,8 @@ pub struct WsTradeRef<'a> {
     pub trade_id: Cow<'a, str>,
     #[serde(alias = "ticker", borrow)]
     pub market_ticker: Cow<'a, str>,
-    #[serde(default)]
-    pub price: Option<i64>,
-    #[serde(default)]
-    pub count: Option<i64>,
     #[serde(borrow)]
     pub count_fp: Cow<'a, str>,
-    #[serde(default)]
-    pub yes_price: Option<i64>,
-    #[serde(default)]
-    pub no_price: Option<i64>,
     #[serde(borrow)]
     pub yes_price_dollars: Cow<'a, str>,
     #[serde(borrow)]
@@ -972,11 +907,7 @@ impl<'a> WsTradeRef<'a> {
         WsTrade {
             trade_id: self.trade_id.into_owned(),
             market_ticker: self.market_ticker.into_owned(),
-            price: self.price,
-            count: self.count,
             count_fp: self.count_fp.into_owned(),
-            yes_price: self.yes_price,
-            no_price: self.no_price,
             yes_price_dollars: self.yes_price_dollars.into_owned(),
             no_price_dollars: self.no_price_dollars.into_owned(),
             taker_side: self.taker_side,
@@ -994,18 +925,6 @@ pub struct WsOrderbookSnapshotRef<'a> {
     pub market_ticker: Cow<'a, str>,
     #[serde(borrow)]
     pub market_id: Cow<'a, str>,
-    /// Price levels: (price_cents, quantity)
-    #[serde(default)]
-    pub yes: Vec<(i64, i64)>,
-    /// Price levels: (price_cents, quantity)
-    #[serde(default)]
-    pub no: Vec<(i64, i64)>,
-    /// Price levels: (price_dollars, quantity)
-    #[serde(default, borrow)]
-    pub yes_dollars: Vec<(Cow<'a, str>, i64)>,
-    /// Price levels: (price_dollars, quantity)
-    #[serde(default, borrow)]
-    pub no_dollars: Vec<(Cow<'a, str>, i64)>,
     /// Price levels: (price_dollars, quantity_fp) - fully fixed-point
     #[serde(default, borrow)]
     pub yes_dollars_fp: Vec<(Cow<'a, str>, Cow<'a, str>)>,
@@ -1019,18 +938,6 @@ impl<'a> WsOrderbookSnapshotRef<'a> {
         WsOrderbookSnapshot {
             market_ticker: self.market_ticker.into_owned(),
             market_id: self.market_id.into_owned(),
-            yes: self.yes,
-            no: self.no,
-            yes_dollars: self
-                .yes_dollars
-                .into_iter()
-                .map(|(p, q)| (p.into_owned(), q))
-                .collect(),
-            no_dollars: self
-                .no_dollars
-                .into_iter()
-                .map(|(p, q)| (p.into_owned(), q))
-                .collect(),
             yes_dollars_fp: self
                 .yes_dollars_fp
                 .into_iter()
@@ -1052,12 +959,8 @@ pub struct WsOrderbookDeltaRef<'a> {
     pub market_ticker: Cow<'a, str>,
     #[serde(borrow)]
     pub market_id: Cow<'a, str>,
-    #[serde(default)]
-    pub price: i64,
     #[serde(borrow)]
     pub price_dollars: Cow<'a, str>,
-    #[serde(default)]
-    pub delta: i64,
     #[serde(borrow)]
     pub delta_fp: Cow<'a, str>,
     pub side: YesNo,
@@ -1076,9 +979,7 @@ impl<'a> WsOrderbookDeltaRef<'a> {
         WsOrderbookDelta {
             market_ticker: self.market_ticker.into_owned(),
             market_id: self.market_id.into_owned(),
-            price: self.price,
             price_dollars: self.price_dollars.into_owned(),
-            delta: self.delta,
             delta_fp: self.delta_fp.into_owned(),
             side: self.side,
             client_order_id: self.client_order_id.map(Cow::into_owned),
@@ -1102,17 +1003,9 @@ pub struct WsFillRef<'a> {
     pub market_ticker: Cow<'a, str>,
     pub side: YesNo,
     pub action: BuySell,
-    #[serde(default)]
-    pub count: i64,
     #[serde(borrow)]
     pub count_fp: Cow<'a, str>,
-    #[serde(default)]
-    pub yes_price: i64,
-    #[serde(default)]
-    pub no_price: i64,
     pub yes_price_dollars: Cow<'a, str>,
-    #[serde(default, borrow)]
-    pub no_price_dollars: Option<Cow<'a, str>>,
     pub is_taker: bool,
     #[serde(borrow)]
     pub fee_cost: Cow<'a, str>,
@@ -1137,12 +1030,8 @@ impl<'a> WsFillRef<'a> {
             market_ticker: self.market_ticker.into_owned(),
             side: self.side,
             action: self.action,
-            count: self.count,
             count_fp: self.count_fp.into_owned(),
-            yes_price: self.yes_price,
-            no_price: self.no_price,
             yes_price_dollars: self.yes_price_dollars.into_owned(),
-            no_price_dollars: self.no_price_dollars.map(Cow::into_owned),
             is_taker: self.is_taker,
             fee_cost: self.fee_cost.into_owned(),
             ts: self.ts,
@@ -3494,9 +3383,7 @@ mod tests {
         let json = r#"{
             "market_ticker":"TEST",
             "market_id":"1",
-            "price":1,
             "price_dollars":"0.01",
-            "delta":1,
             "delta_fp":"1",
             "side":"yes"
         }"#;

--- a/src/ws/types.rs
+++ b/src/ws/types.rs
@@ -427,9 +427,8 @@ pub struct WsFill {
     pub yes_price: i64,
     #[serde(default)]
     pub no_price: i64,
-    #[serde(alias = "yes_price_fixed")]
     pub yes_price_dollars: String,
-    #[serde(default, alias = "no_price_fixed")]
+    #[serde(default)]
     pub no_price_dollars: Option<String>,
     pub is_taker: bool,
     pub fee_cost: String,
@@ -669,11 +668,7 @@ pub struct WsRfqCreated {
     #[serde(default)]
     pub event_ticker: Option<String>,
     #[serde(default)]
-    pub contracts: Option<i64>,
-    #[serde(default)]
     pub contracts_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub target_cost: Option<i64>,
     #[serde(default)]
     pub target_cost_dollars: Option<FixedPointDollars>,
     pub created_ts: String,
@@ -691,11 +686,7 @@ pub struct WsRfqDeleted {
     #[serde(default)]
     pub event_ticker: Option<String>,
     #[serde(default)]
-    pub contracts: Option<i64>,
-    #[serde(default)]
     pub contracts_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub target_cost: Option<i64>,
     #[serde(default)]
     pub target_cost_dollars: Option<FixedPointDollars>,
     pub deleted_ts: String,
@@ -709,20 +700,12 @@ pub struct WsQuoteCreated {
     pub market_ticker: String,
     #[serde(default)]
     pub event_ticker: Option<String>,
-    pub yes_bid: i64,
-    pub no_bid: i64,
     pub yes_bid_dollars: FixedPointDollars,
     pub no_bid_dollars: FixedPointDollars,
-    #[serde(default)]
-    pub yes_contracts_offered: Option<i64>,
-    #[serde(default)]
-    pub no_contracts_offered: Option<i64>,
     #[serde(default)]
     pub yes_contracts_offered_fp: Option<FixedPointCount>,
     #[serde(default)]
     pub no_contracts_offered_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub rfq_target_cost: Option<i64>,
     #[serde(default)]
     pub rfq_target_cost_dollars: Option<FixedPointDollars>,
     pub created_ts: String,
@@ -736,26 +719,16 @@ pub struct WsQuoteAccepted {
     pub market_ticker: String,
     #[serde(default)]
     pub event_ticker: Option<String>,
-    pub yes_bid: i64,
-    pub no_bid: i64,
     pub yes_bid_dollars: FixedPointDollars,
     pub no_bid_dollars: FixedPointDollars,
     #[serde(default)]
     pub accepted_side: Option<YesNo>,
-    #[serde(default)]
-    pub contracts_accepted: Option<i64>,
-    #[serde(default)]
-    pub yes_contracts_offered: Option<i64>,
-    #[serde(default)]
-    pub no_contracts_offered: Option<i64>,
     #[serde(default)]
     pub contracts_accepted_fp: Option<FixedPointCount>,
     #[serde(default)]
     pub yes_contracts_offered_fp: Option<FixedPointCount>,
     #[serde(default)]
     pub no_contracts_offered_fp: Option<FixedPointCount>,
-    #[serde(default)]
-    pub rfq_target_cost: Option<i64>,
     #[serde(default)]
     pub rfq_target_cost_dollars: Option<FixedPointDollars>,
 }
@@ -792,39 +765,33 @@ pub type FixedPointCountRef<'a> = Cow<'a, str>;
 pub struct MarketPositionRef<'a> {
     #[serde(borrow)]
     pub ticker: Cow<'a, str>,
+    #[serde(borrow)]
+    pub total_traded_dollars: FixedPointDollarsRef<'a>,
+    #[serde(borrow)]
+    pub position_fp: FixedPointCountRef<'a>,
+    #[serde(borrow)]
+    pub market_exposure_dollars: FixedPointDollarsRef<'a>,
+    #[serde(borrow)]
+    pub realized_pnl_dollars: FixedPointDollarsRef<'a>,
     #[serde(default)]
-    pub position: Option<i64>,
-    #[serde(default, borrow)]
-    pub position_fp: Option<FixedPointCountRef<'a>>,
-    #[serde(default)]
-    pub fees_paid: Option<i64>,
-    #[serde(default, borrow)]
-    pub fees_paid_fp: Option<FixedPointDollarsRef<'a>>,
-    #[serde(default)]
-    pub resting_orders: Option<i64>,
-    #[serde(default, borrow)]
-    pub resting_orders_fp: Option<FixedPointCountRef<'a>>,
-    #[serde(default)]
-    pub total_traded: Option<i64>,
-    #[serde(default, borrow)]
-    pub total_traded_fp: Option<FixedPointCountRef<'a>>,
-    #[serde(default)]
-    pub subaccount: Option<u32>,
+    pub resting_orders_count: Option<i32>,
+    #[serde(borrow)]
+    pub fees_paid_dollars: FixedPointDollarsRef<'a>,
+    #[serde(borrow)]
+    pub last_updated_ts: Cow<'a, str>,
 }
 
 impl<'a> MarketPositionRef<'a> {
     pub fn into_owned(self) -> MarketPosition {
         MarketPosition {
             ticker: self.ticker.into_owned(),
-            position: self.position,
-            position_fp: self.position_fp.map(Cow::into_owned),
-            fees_paid: self.fees_paid,
-            fees_paid_fp: self.fees_paid_fp.map(Cow::into_owned),
-            resting_orders: self.resting_orders,
-            resting_orders_fp: self.resting_orders_fp.map(Cow::into_owned),
-            total_traded: self.total_traded,
-            total_traded_fp: self.total_traded_fp.map(Cow::into_owned),
-            subaccount: self.subaccount,
+            total_traded_dollars: self.total_traded_dollars.into_owned(),
+            position_fp: self.position_fp.into_owned(),
+            market_exposure_dollars: self.market_exposure_dollars.into_owned(),
+            realized_pnl_dollars: self.realized_pnl_dollars.into_owned(),
+            resting_orders_count: self.resting_orders_count,
+            fees_paid_dollars: self.fees_paid_dollars.into_owned(),
+            last_updated_ts: self.last_updated_ts.into_owned(),
         }
     }
 }
@@ -833,39 +800,27 @@ impl<'a> MarketPositionRef<'a> {
 pub struct EventPositionRef<'a> {
     #[serde(borrow)]
     pub event_ticker: Cow<'a, str>,
-    #[serde(default)]
-    pub position: Option<i64>,
-    #[serde(default, borrow)]
-    pub position_fp: Option<FixedPointCountRef<'a>>,
-    #[serde(default)]
-    pub fees_paid: Option<i64>,
-    #[serde(default, borrow)]
-    pub fees_paid_fp: Option<FixedPointDollarsRef<'a>>,
-    #[serde(default)]
-    pub resting_orders: Option<i64>,
-    #[serde(default, borrow)]
-    pub resting_orders_fp: Option<FixedPointCountRef<'a>>,
-    #[serde(default)]
-    pub total_traded: Option<i64>,
-    #[serde(default, borrow)]
-    pub total_traded_fp: Option<FixedPointCountRef<'a>>,
-    #[serde(default)]
-    pub subaccount: Option<u32>,
+    #[serde(borrow)]
+    pub total_cost_dollars: FixedPointDollarsRef<'a>,
+    #[serde(borrow)]
+    pub total_cost_shares_fp: FixedPointCountRef<'a>,
+    #[serde(borrow)]
+    pub event_exposure_dollars: FixedPointDollarsRef<'a>,
+    #[serde(borrow)]
+    pub realized_pnl_dollars: FixedPointDollarsRef<'a>,
+    #[serde(borrow)]
+    pub fees_paid_dollars: FixedPointDollarsRef<'a>,
 }
 
 impl<'a> EventPositionRef<'a> {
     pub fn into_owned(self) -> EventPosition {
         EventPosition {
             event_ticker: self.event_ticker.into_owned(),
-            position: self.position,
-            position_fp: self.position_fp.map(Cow::into_owned),
-            fees_paid: self.fees_paid,
-            fees_paid_fp: self.fees_paid_fp.map(Cow::into_owned),
-            resting_orders: self.resting_orders,
-            resting_orders_fp: self.resting_orders_fp.map(Cow::into_owned),
-            total_traded: self.total_traded,
-            total_traded_fp: self.total_traded_fp.map(Cow::into_owned),
-            subaccount: self.subaccount,
+            total_cost_dollars: self.total_cost_dollars.into_owned(),
+            total_cost_shares_fp: self.total_cost_shares_fp.into_owned(),
+            event_exposure_dollars: self.event_exposure_dollars.into_owned(),
+            realized_pnl_dollars: self.realized_pnl_dollars.into_owned(),
+            fees_paid_dollars: self.fees_paid_dollars.into_owned(),
         }
     }
 }
@@ -1155,9 +1110,8 @@ pub struct WsFillRef<'a> {
     pub yes_price: i64,
     #[serde(default)]
     pub no_price: i64,
-    #[serde(alias = "yes_price_fixed", borrow)]
     pub yes_price_dollars: Cow<'a, str>,
-    #[serde(default, alias = "no_price_fixed", borrow)]
+    #[serde(default, borrow)]
     pub no_price_dollars: Option<Cow<'a, str>>,
     pub is_taker: bool,
     #[serde(borrow)]
@@ -1498,12 +1452,8 @@ pub struct WsRfqCreatedRef<'a> {
     pub market_ticker: Cow<'a, str>,
     #[serde(default, borrow)]
     pub event_ticker: Option<Cow<'a, str>>,
-    #[serde(default)]
-    pub contracts: Option<i64>,
     #[serde(default, borrow)]
     pub contracts_fp: Option<FixedPointCountRef<'a>>,
-    #[serde(default)]
-    pub target_cost: Option<i64>,
     #[serde(default, borrow)]
     pub target_cost_dollars: Option<FixedPointDollarsRef<'a>>,
     #[serde(borrow)]
@@ -1521,9 +1471,7 @@ impl<'a> WsRfqCreatedRef<'a> {
             creator_id: self.creator_id.into_owned(),
             market_ticker: self.market_ticker.into_owned(),
             event_ticker: self.event_ticker.map(Cow::into_owned),
-            contracts: self.contracts,
             contracts_fp: self.contracts_fp.map(Cow::into_owned),
-            target_cost: self.target_cost,
             target_cost_dollars: self.target_cost_dollars.map(Cow::into_owned),
             created_ts: self.created_ts.into_owned(),
             mve_collection_ticker: self.mve_collection_ticker.map(Cow::into_owned),
@@ -1546,12 +1494,8 @@ pub struct WsRfqDeletedRef<'a> {
     pub market_ticker: Cow<'a, str>,
     #[serde(default, borrow)]
     pub event_ticker: Option<Cow<'a, str>>,
-    #[serde(default)]
-    pub contracts: Option<i64>,
     #[serde(default, borrow)]
     pub contracts_fp: Option<FixedPointCountRef<'a>>,
-    #[serde(default)]
-    pub target_cost: Option<i64>,
     #[serde(default, borrow)]
     pub target_cost_dollars: Option<FixedPointDollarsRef<'a>>,
     #[serde(borrow)]
@@ -1565,9 +1509,7 @@ impl<'a> WsRfqDeletedRef<'a> {
             creator_id: self.creator_id.into_owned(),
             market_ticker: self.market_ticker.into_owned(),
             event_ticker: self.event_ticker.map(Cow::into_owned),
-            contracts: self.contracts,
             contracts_fp: self.contracts_fp.map(Cow::into_owned),
-            target_cost: self.target_cost,
             target_cost_dollars: self.target_cost_dollars.map(Cow::into_owned),
             deleted_ts: self.deleted_ts.into_owned(),
         }
@@ -1586,22 +1528,14 @@ pub struct WsQuoteCreatedRef<'a> {
     pub market_ticker: Cow<'a, str>,
     #[serde(default, borrow)]
     pub event_ticker: Option<Cow<'a, str>>,
-    pub yes_bid: i64,
-    pub no_bid: i64,
     #[serde(borrow)]
     pub yes_bid_dollars: FixedPointDollarsRef<'a>,
     #[serde(borrow)]
     pub no_bid_dollars: FixedPointDollarsRef<'a>,
-    #[serde(default)]
-    pub yes_contracts_offered: Option<i64>,
-    #[serde(default)]
-    pub no_contracts_offered: Option<i64>,
     #[serde(default, borrow)]
     pub yes_contracts_offered_fp: Option<FixedPointCountRef<'a>>,
     #[serde(default, borrow)]
     pub no_contracts_offered_fp: Option<FixedPointCountRef<'a>>,
-    #[serde(default)]
-    pub rfq_target_cost: Option<i64>,
     #[serde(default, borrow)]
     pub rfq_target_cost_dollars: Option<FixedPointDollarsRef<'a>>,
     #[serde(borrow)]
@@ -1616,15 +1550,10 @@ impl<'a> WsQuoteCreatedRef<'a> {
             quote_creator_id: self.quote_creator_id.into_owned(),
             market_ticker: self.market_ticker.into_owned(),
             event_ticker: self.event_ticker.map(Cow::into_owned),
-            yes_bid: self.yes_bid,
-            no_bid: self.no_bid,
             yes_bid_dollars: self.yes_bid_dollars.into_owned(),
             no_bid_dollars: self.no_bid_dollars.into_owned(),
-            yes_contracts_offered: self.yes_contracts_offered,
-            no_contracts_offered: self.no_contracts_offered,
             yes_contracts_offered_fp: self.yes_contracts_offered_fp.map(Cow::into_owned),
             no_contracts_offered_fp: self.no_contracts_offered_fp.map(Cow::into_owned),
-            rfq_target_cost: self.rfq_target_cost,
             rfq_target_cost_dollars: self.rfq_target_cost_dollars.map(Cow::into_owned),
             created_ts: self.created_ts.into_owned(),
         }
@@ -1643,28 +1572,18 @@ pub struct WsQuoteAcceptedRef<'a> {
     pub market_ticker: Cow<'a, str>,
     #[serde(default, borrow)]
     pub event_ticker: Option<Cow<'a, str>>,
-    pub yes_bid: i64,
-    pub no_bid: i64,
     #[serde(borrow)]
     pub yes_bid_dollars: FixedPointDollarsRef<'a>,
     #[serde(borrow)]
     pub no_bid_dollars: FixedPointDollarsRef<'a>,
     #[serde(default)]
     pub accepted_side: Option<YesNo>,
-    #[serde(default)]
-    pub contracts_accepted: Option<i64>,
-    #[serde(default)]
-    pub yes_contracts_offered: Option<i64>,
-    #[serde(default)]
-    pub no_contracts_offered: Option<i64>,
     #[serde(default, borrow)]
     pub contracts_accepted_fp: Option<FixedPointCountRef<'a>>,
     #[serde(default, borrow)]
     pub yes_contracts_offered_fp: Option<FixedPointCountRef<'a>>,
     #[serde(default, borrow)]
     pub no_contracts_offered_fp: Option<FixedPointCountRef<'a>>,
-    #[serde(default)]
-    pub rfq_target_cost: Option<i64>,
     #[serde(default, borrow)]
     pub rfq_target_cost_dollars: Option<FixedPointDollarsRef<'a>>,
 }
@@ -1677,18 +1596,12 @@ impl<'a> WsQuoteAcceptedRef<'a> {
             quote_creator_id: self.quote_creator_id.into_owned(),
             market_ticker: self.market_ticker.into_owned(),
             event_ticker: self.event_ticker.map(Cow::into_owned),
-            yes_bid: self.yes_bid,
-            no_bid: self.no_bid,
             yes_bid_dollars: self.yes_bid_dollars.into_owned(),
             no_bid_dollars: self.no_bid_dollars.into_owned(),
             accepted_side: self.accepted_side,
-            contracts_accepted: self.contracts_accepted,
-            yes_contracts_offered: self.yes_contracts_offered,
-            no_contracts_offered: self.no_contracts_offered,
             contracts_accepted_fp: self.contracts_accepted_fp.map(Cow::into_owned),
             yes_contracts_offered_fp: self.yes_contracts_offered_fp.map(Cow::into_owned),
             no_contracts_offered_fp: self.no_contracts_offered_fp.map(Cow::into_owned),
-            rfq_target_cost: self.rfq_target_cost,
             rfq_target_cost_dollars: self.rfq_target_cost_dollars.map(Cow::into_owned),
         }
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -29,6 +29,7 @@ pub fn demo_env() -> KalshiEnvironment {
     KalshiEnvironment::demo()
 }
 
+#[allow(dead_code)]
 pub fn demo_client() -> KalshiRestClient {
     KalshiRestClient::builder(demo_env())
         .with_rate_limit_config(RateLimitConfig {
@@ -46,6 +47,7 @@ pub fn demo_client() -> KalshiRestClient {
         .expect("build live test client")
 }
 
+#[allow(dead_code)]
 pub fn demo_auth_client(auth: KalshiAuth) -> KalshiRestClient {
     KalshiRestClient::builder(demo_env())
         .with_auth(auth)

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -6,12 +6,13 @@ use kalshi_fast::{
     ErrorResponse, EventData, EventMetadata, EventStatus, GetAccountApiLimitsResponse,
     GetEventsParams, GetExchangeAnnouncementsResponse, GetExchangeScheduleResponse,
     GetExchangeStatusResponse, GetFillsParams, GetFillsResponse, GetMarketOrderbookResponse,
-    GetMarketsParams, GetOrdersParams, GetPositionsParams, GetSeriesFeeChangesParams,
-    GetSeriesFeeChangesResponse, GetSettlementsParams, GetSettlementsResponse,
-    GetSubaccountBalancesResponse, GetSubaccountTransfersParams, GetSubaccountTransfersResponse,
-    GetTradesParams, GetTradesResponse, GetUserDataTimestampResponse, MarketMetadata, MarketStatus,
-    MarketStatusConversionError, MarketStatusQuery, MveFilter, OrderStatus, OrderType,
-    PositionCountFilter, PriceRange, SelfTradePreventionType, TimeInForce, YesNo,
+    GetMarketsParams, GetOrderQueuePositionsParams, GetOrdersParams, GetPositionsParams,
+    GetSeriesFeeChangesParams, GetSeriesFeeChangesResponse, GetSettlementsParams,
+    GetSettlementsResponse, GetSubaccountBalancesResponse, GetSubaccountTransfersParams,
+    GetSubaccountTransfersResponse, GetTradesParams, GetTradesResponse,
+    GetUserDataTimestampResponse, MarketMetadata, MarketStatus, MarketStatusConversionError,
+    MarketStatusQuery, MveFilter, OrderStatus, OrderType, PositionCountFilter, PriceRange,
+    SelfTradePreventionType, TimeInForce, YesNo,
 };
 
 // ============================================================================
@@ -991,12 +992,6 @@ fn cancel_order_response_deserializes() {
 #[test]
 fn get_market_orderbook_response_deserializes() {
     let json = r#"{
-        "orderbook": {
-            "yes": [[50, 100]],
-            "no": [[49, 200]],
-            "yes_dollars": [["0.50", 100]],
-            "no_dollars": [["0.49", 200]]
-        },
         "orderbook_fp": {
             "yes_dollars": [["0.50", "100.00"]],
             "no_dollars": [["0.49", "200.00"]]
@@ -1004,7 +999,6 @@ fn get_market_orderbook_response_deserializes() {
     }"#;
 
     let resp: GetMarketOrderbookResponse = serde_json::from_str(json).unwrap();
-    assert_eq!(resp.orderbook.yes.len(), 1);
     assert_eq!(resp.orderbook_fp.yes_dollars.len(), 1);
 }
 
@@ -1340,6 +1334,11 @@ fn get_positions_params_validates_subaccount_bounds() {
         ..Default::default()
     };
     assert!(params.validate().is_err());
+}
+
+#[test]
+fn get_order_queue_positions_params_allows_unfiltered_requests() {
+    assert!(GetOrderQueuePositionsParams::default().validate().is_ok());
 }
 
 #[test]

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -497,12 +497,19 @@ fn get_balance_response_deserializes() {
 #[test]
 fn get_markets_response_deserializes() {
     let json = r#"{
-        "markets": [{"ticker": "MKT-1"}, {"ticker": "MKT-2"}],
+        "markets": [
+            {"ticker": "MKT-1", "occurrence_datetime": "2026-04-16T18:30:00Z"},
+            {"ticker": "MKT-2"}
+        ],
         "cursor": "next_cursor_token"
     }"#;
 
     let resp: kalshi_fast::GetMarketsResponse = serde_json::from_str(json).unwrap();
     assert_eq!(resp.markets.len(), 2);
+    assert_eq!(
+        resp.markets[0].occurrence_datetime.as_deref(),
+        Some("2026-04-16T18:30:00Z")
+    );
     assert_eq!(resp.cursor, Some("next_cursor_token".into()));
 }
 
@@ -606,6 +613,7 @@ fn get_event_response_deserializes_rich_schema_fields() {
             "liquidity": 1000,
             "liquidity_dollars": "10.0000",
             "expiration_value": "123.4",
+            "occurrence_datetime": "2026-04-16T18:30:00Z",
             "tick_size": 1,
             "expected_expiration_time": "2023-11-07T05:31:56Z",
             "settlement_value": 100,
@@ -633,6 +641,10 @@ fn get_event_response_deserializes_rich_schema_fields() {
     assert_eq!(
         resp.markets[0].liquidity_dollars.as_deref(),
         Some("10.0000")
+    );
+    assert_eq!(
+        resp.markets[0].occurrence_datetime.as_deref(),
+        Some("2026-04-16T18:30:00Z")
     );
     assert_eq!(resp.markets[0].strike_type.as_deref(), Some("greater"));
 }
@@ -826,22 +838,55 @@ fn get_historical_cutoff_response_deserializes() {
 #[test]
 fn get_positions_response_deserializes() {
     let json = r#"{
-        "market_positions": [{"ticker": "MKT-1", "position": 100}],
-        "event_positions": [],
+        "market_positions": [{
+            "ticker": "MKT-1",
+            "total_traded_dollars": "12.3400",
+            "position_fp": "5.00",
+            "market_exposure_dollars": "3.2100",
+            "realized_pnl_dollars": "1.1100",
+            "resting_orders_count": 2,
+            "fees_paid_dollars": "0.2200",
+            "last_updated_ts": "2026-04-16T12:00:00Z"
+        }],
+        "event_positions": [{
+            "event_ticker": "EVT-1",
+            "total_cost_dollars": "12.3400",
+            "total_cost_shares_fp": "10.00",
+            "event_exposure_dollars": "3.2100",
+            "realized_pnl_dollars": "1.1100",
+            "fees_paid_dollars": "0.2200"
+        }],
         "cursor": "abc123"
     }"#;
 
     let resp: kalshi_fast::GetPositionsResponse = serde_json::from_str(json).unwrap();
     assert_eq!(resp.market_positions.len(), 1);
-    assert!(resp.event_positions.is_empty());
+    assert_eq!(resp.market_positions[0].position_fp, "5.00");
+    assert_eq!(resp.event_positions.len(), 1);
     assert_eq!(resp.cursor, Some("abc123".into()));
 }
 
 #[test]
 fn positions_page_from_response() {
     let json = r#"{
-        "market_positions": [{"ticker": "MKT-1", "position": 100}],
-        "event_positions": [{"event_ticker": "EVT-1", "position": 5}],
+        "market_positions": [{
+            "ticker": "MKT-1",
+            "total_traded_dollars": "12.3400",
+            "position_fp": "5.00",
+            "market_exposure_dollars": "3.2100",
+            "realized_pnl_dollars": "1.1100",
+            "resting_orders_count": 2,
+            "fees_paid_dollars": "0.2200",
+            "last_updated_ts": "2026-04-16T12:00:00Z"
+        }],
+        "event_positions": [{
+            "event_ticker": "EVT-1",
+            "total_cost_dollars": "12.3400",
+            "total_cost_shares_fp": "10.00",
+            "event_exposure_dollars": "3.2100",
+            "realized_pnl_dollars": "1.1100",
+            "fees_paid_dollars": "0.2200"
+        }],
         "cursor": "abc123"
     }"#;
 
@@ -849,23 +894,61 @@ fn positions_page_from_response() {
     let page: kalshi_fast::PositionsPage = resp.into();
     assert_eq!(page.market_positions.len(), 1);
     assert_eq!(page.event_positions.len(), 1);
+    assert_eq!(page.event_positions[0].total_cost_shares_fp, "10.00");
 }
 
 #[test]
 fn get_orders_response_deserializes() {
     let json = r#"{
-        "orders": [{"order_id": "ord-1", "ticker": "MKT-1", "status": "resting"}]
+        "orders": [{
+            "order_id": "ord-1",
+            "user_id": "user-1",
+            "client_order_id": "client-1",
+            "ticker": "MKT-1",
+            "side": "yes",
+            "action": "buy",
+            "type": "limit",
+            "status": "resting",
+            "yes_price_dollars": "0.5500",
+            "no_price_dollars": "0.4500",
+            "fill_count_fp": "0.00",
+            "remaining_count_fp": "10.00",
+            "initial_count_fp": "10.00",
+            "taker_fill_cost_dollars": "0.0000",
+            "maker_fill_cost_dollars": "0.0000",
+            "taker_fees_dollars": "0.0000",
+            "maker_fees_dollars": "0.0000"
+        }]
     }"#;
 
     let resp: kalshi_fast::GetOrdersResponse = serde_json::from_str(json).unwrap();
     assert_eq!(resp.orders.len(), 1);
+    assert_eq!(resp.orders[0].client_order_id, "client-1");
     assert!(resp.cursor.is_none());
 }
 
 #[test]
 fn create_order_response_deserializes() {
     let json = r#"{
-        "order": {"order_id": "ord-123", "ticker": "MKT-1", "status": "resting"}
+        "order": {
+            "order_id": "ord-123",
+            "user_id": "user-1",
+            "client_order_id": "client-1",
+            "ticker": "MKT-1",
+            "side": "yes",
+            "action": "buy",
+            "type": "limit",
+            "status": "resting",
+            "yes_price_dollars": "0.5500",
+            "no_price_dollars": "0.4500",
+            "fill_count_fp": "0.00",
+            "remaining_count_fp": "10.00",
+            "initial_count_fp": "10.00",
+            "taker_fill_cost_dollars": "0.0000",
+            "maker_fill_cost_dollars": "0.0000",
+            "taker_fees_dollars": "0.0000",
+            "maker_fees_dollars": "0.0000"
+        }
     }"#;
 
     let resp: kalshi_fast::CreateOrderResponse = serde_json::from_str(json).unwrap();
@@ -876,15 +959,33 @@ fn create_order_response_deserializes() {
 #[test]
 fn cancel_order_response_deserializes() {
     let json = r#"{
-        "order": {"order_id": "ord-123", "ticker": "MKT-1", "status": "canceled"},
+        "order": {
+            "order_id": "ord-123",
+            "user_id": "user-1",
+            "client_order_id": "client-1",
+            "ticker": "MKT-1",
+            "side": "yes",
+            "action": "buy",
+            "type": "limit",
+            "status": "canceled",
+            "yes_price_dollars": "0.5500",
+            "no_price_dollars": "0.4500",
+            "fill_count_fp": "0.00",
+            "remaining_count_fp": "5.00",
+            "initial_count_fp": "10.00",
+            "taker_fill_cost_dollars": "0.0000",
+            "maker_fill_cost_dollars": "0.0000",
+            "taker_fees_dollars": "0.0000",
+            "maker_fees_dollars": "0.0000"
+        },
         "reduced_by": 5,
-        "reduced_by_fp": "5.0"
+        "reduced_by_fp": "5.00"
     }"#;
 
     let resp: kalshi_fast::CancelOrderResponse = serde_json::from_str(json).unwrap();
-    assert_eq!(resp.order.status, Some(OrderStatus::Canceled));
+    assert_eq!(resp.order.status, OrderStatus::Canceled);
     assert_eq!(resp.reduced_by, 5);
-    assert_eq!(resp.reduced_by_fp, "5.0");
+    assert_eq!(resp.reduced_by_fp, "5.00");
 }
 
 #[test]
@@ -910,12 +1011,21 @@ fn get_market_orderbook_response_deserializes() {
 #[test]
 fn get_trades_response_deserializes() {
     let json = r#"{
-        "trades": [{"trade_id":"t1","ticker":"MKT-1","price":55}],
+        "trades": [{
+            "trade_id": "t1",
+            "ticker": "MKT-1",
+            "count_fp": "2.00",
+            "yes_price_dollars": "0.5500",
+            "no_price_dollars": "0.4500",
+            "taker_side": "yes",
+            "created_time": "2026-04-16T12:00:00Z"
+        }],
         "cursor": "c1"
     }"#;
 
     let resp: GetTradesResponse = serde_json::from_str(json).unwrap();
     assert_eq!(resp.trades.len(), 1);
+    assert_eq!(resp.trades[0].count_fp, "2.00");
     assert_eq!(resp.cursor, Some("c1".into()));
 }
 
@@ -995,7 +1105,20 @@ fn get_series_fee_changes_response_deserializes() {
 #[test]
 fn get_fills_response_deserializes() {
     let json = r#"{
-        "fills": [{"fill_id":"f1","order_id":"o1","trade_id":"t1","ticker":"MKT-1"}],
+        "fills": [{
+            "fill_id": "f1",
+            "order_id": "o1",
+            "trade_id": "t1",
+            "ticker": "MKT-1",
+            "market_ticker": "MKT-1",
+            "side": "yes",
+            "action": "buy",
+            "count_fp": "1.00",
+            "yes_price_dollars": "0.5500",
+            "no_price_dollars": "0.4500",
+            "is_taker": true,
+            "fee_cost": "0.0100"
+        }],
         "cursor": "c1"
     }"#;
 
@@ -1007,7 +1130,18 @@ fn get_fills_response_deserializes() {
 #[test]
 fn get_settlements_response_deserializes() {
     let json = r#"{
-        "settlements": [{"settlement_id":"s1","ticker":"MKT-1"}],
+        "settlements": [{
+            "ticker": "MKT-1",
+            "event_ticker": "EVT-1",
+            "market_result": "yes",
+            "yes_count_fp": "1.00",
+            "yes_total_cost_dollars": "0.5500",
+            "no_count_fp": "0.00",
+            "no_total_cost_dollars": "0.0000",
+            "revenue": 100,
+            "settled_time": "2026-04-02T00:00:00Z",
+            "fee_cost": "0.0100"
+        }],
         "cursor": null
     }"#;
 
@@ -1554,10 +1688,7 @@ fn quotes_and_rfqs_responses_deserialize_typed() {
             "creator_id": "u-1",
             "rfq_creator_id": "u-2",
             "market_ticker": "MKT-1",
-            "contracts": 10,
             "contracts_fp": "10.00",
-            "yes_bid": 44,
-            "no_bid": 56,
             "yes_bid_dollars": "0.4400",
             "no_bid_dollars": "0.5600",
             "created_ts": "2023-11-07T05:31:56Z",
@@ -1568,6 +1699,7 @@ fn quotes_and_rfqs_responses_deserialize_typed() {
     }"#;
     let quotes: kalshi_fast::GetQuotesResponse = serde_json::from_str(quotes_json).unwrap();
     assert_eq!(quotes.quotes.len(), 1);
+    assert_eq!(quotes.quotes[0].rfq_creator_id, "u-2");
     assert_eq!(
         quotes.quotes[0].rfq_target_cost_dollars.as_deref(),
         Some("100.0000")
@@ -1578,7 +1710,6 @@ fn quotes_and_rfqs_responses_deserialize_typed() {
             "id": "r-1",
             "creator_id": "u-1",
             "market_ticker": "MKT-1",
-            "contracts": 10,
             "contracts_fp": "10.00",
             "target_cost_dollars": "100.0000",
             "status": "open",
@@ -1649,7 +1780,25 @@ fn batch_order_responses_deserialize_typed() {
     let create_json = r#"{
         "orders": [{
             "client_order_id": "c-1",
-            "order": {"order_id": "o-1", "ticker": "MKT-1"},
+            "order": {
+                "order_id": "o-1",
+                "user_id": "user-1",
+                "client_order_id": "c-1",
+                "ticker": "MKT-1",
+                "side": "yes",
+                "action": "buy",
+                "type": "limit",
+                "status": "resting",
+                "yes_price_dollars": "0.5500",
+                "no_price_dollars": "0.4500",
+                "fill_count_fp": "0.00",
+                "remaining_count_fp": "10.00",
+                "initial_count_fp": "10.00",
+                "taker_fill_cost_dollars": "0.0000",
+                "maker_fill_cost_dollars": "0.0000",
+                "taker_fees_dollars": "0.0000",
+                "maker_fees_dollars": "0.0000"
+            },
             "error": null
         }]
     }"#;
@@ -1667,7 +1816,25 @@ fn batch_order_responses_deserialize_typed() {
     let cancel_json = r#"{
         "orders": [{
             "order_id": "o-1",
-            "order": {"order_id": "o-1", "ticker": "MKT-1"},
+            "order": {
+                "order_id": "o-1",
+                "user_id": "user-1",
+                "client_order_id": "c-1",
+                "ticker": "MKT-1",
+                "side": "yes",
+                "action": "buy",
+                "type": "limit",
+                "status": "canceled",
+                "yes_price_dollars": "0.5500",
+                "no_price_dollars": "0.4500",
+                "fill_count_fp": "0.00",
+                "remaining_count_fp": "0.00",
+                "initial_count_fp": "10.00",
+                "taker_fill_cost_dollars": "0.0000",
+                "maker_fill_cost_dollars": "0.0000",
+                "taker_fees_dollars": "0.0000",
+                "maker_fees_dollars": "0.0000"
+            },
             "reduced_by": 1,
             "reduced_by_fp": "1.00",
             "error": null
@@ -1680,92 +1847,52 @@ fn batch_order_responses_deserialize_typed() {
 }
 
 #[test]
-fn fills_deserialize_current_and_legacy_price_fields() {
-    let current_json = r#"{
+fn fills_deserialize_current_schema() {
+    let json = r#"{
         "fills": [{
             "fill_id": "f-1",
             "order_id": "o-1",
             "trade_id": "t-1",
             "ticker": "MKT-1",
+            "market_ticker": "MKT-1",
+            "side": "yes",
+            "action": "buy",
             "count_fp": "1.00",
             "yes_price_dollars": "0.5500",
-            "no_price_dollars": "0.4500"
+            "no_price_dollars": "0.4500",
+            "is_taker": true,
+            "fee_cost": "0.0100",
+            "ts": 1771113600
         }]
     }"#;
-    let current: kalshi_fast::GetFillsResponse = serde_json::from_str(current_json).unwrap();
-    assert_eq!(
-        current.fills[0].yes_price_dollars.as_deref(),
-        Some("0.5500")
-    );
-    assert_eq!(current.fills[0].no_price_dollars.as_deref(), Some("0.4500"));
-
-    let legacy_json = r#"{
-        "fills": [{
-            "fill_id": "f-2",
-            "order_id": "o-2",
-            "trade_id": "t-2",
-            "ticker": "MKT-2",
-            "count_fp": "2.00",
-            "yes_price_fixed": "0.6000",
-            "no_price_fixed": "0.4000"
-        }]
-    }"#;
-    let legacy: kalshi_fast::GetFillsResponse = serde_json::from_str(legacy_json).unwrap();
-    assert_eq!(legacy.fills[0].yes_price_dollars.as_deref(), Some("0.6000"));
-    assert_eq!(legacy.fills[0].no_price_dollars.as_deref(), Some("0.4000"));
+    let current: kalshi_fast::GetFillsResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(current.fills[0].yes_price_dollars, "0.5500");
+    assert_eq!(current.fills[0].no_price_dollars, "0.4500");
+    assert_eq!(current.fills[0].ts, Some(1771113600));
 }
 
 #[test]
-fn settlements_deserialize_current_and_legacy_cost_fields() {
-    let current_json = r#"{
+fn settlements_deserialize_current_schema() {
+    let json = r#"{
         "settlements": [{
-            "settlement_id": "s-1",
             "ticker": "MKT-1",
+            "event_ticker": "EVT-1",
+            "market_result": "yes",
             "yes_count_fp": "1.00",
             "yes_total_cost_dollars": "0.5500",
             "no_count_fp": "0.00",
             "no_total_cost_dollars": "0.0000",
-            "revenue": "1.0000",
+            "revenue": 100,
             "settled_time": "2026-04-02T00:00:00Z",
             "fee_cost": "0.0100",
-            "value": "0.9900",
-            "created_time": "2026-04-02T00:00:00Z"
+            "value": 99
         }]
     }"#;
-    let current: kalshi_fast::GetSettlementsResponse = serde_json::from_str(current_json).unwrap();
-    assert_eq!(
-        current.settlements[0].yes_total_cost_dollars.as_deref(),
-        Some("0.5500")
-    );
-    assert_eq!(
-        current.settlements[0].no_total_cost_dollars.as_deref(),
-        Some("0.0000")
-    );
-
-    let legacy_json = r#"{
-        "settlements": [{
-            "settlement_id": "s-2",
-            "ticker": "MKT-2",
-            "yes_count_fp": "1.00",
-            "yes_total_cost": "0.6500",
-            "no_count_fp": "0.00",
-            "no_total_cost": "0.0000",
-            "revenue": "1.0000",
-            "settled_time": "2026-04-02T00:00:00Z",
-            "fee_cost": "0.0100",
-            "value": "0.9900",
-            "created_time": "2026-04-02T00:00:00Z"
-        }]
-    }"#;
-    let legacy: kalshi_fast::GetSettlementsResponse = serde_json::from_str(legacy_json).unwrap();
-    assert_eq!(
-        legacy.settlements[0].yes_total_cost_dollars.as_deref(),
-        Some("0.6500")
-    );
-    assert_eq!(
-        legacy.settlements[0].no_total_cost_dollars.as_deref(),
-        Some("0.0000")
-    );
+    let current: kalshi_fast::GetSettlementsResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(current.settlements[0].yes_total_cost_dollars, "0.5500");
+    assert_eq!(current.settlements[0].no_total_cost_dollars, "0.0000");
+    assert_eq!(current.settlements[0].revenue, 100);
+    assert_eq!(current.settlements[0].value, Some(99));
 }
 
 #[test]

--- a/tests/rest_auth.rs
+++ b/tests/rest_auth.rs
@@ -5,9 +5,10 @@ mod common;
 use kalshi_fast::{
     EventStatus, GetEventForecastPercentileHistoryParams, GetEventsParams, GetFillsParams,
     GetOrderQueuePositionsParams, GetOrdersParams, GetPositionsParams, GetQuotesParams,
-    GetRFQsParams, GetSettlementsParams, GetSubaccountTransfersParams, KalshiError,
-    KalshiRestClient, SubaccountQueryParams,
+    GetRFQsParams, GetSettlementsParams, GetSubaccountTransfersParams, KalshiError, OrderStatus,
+    SubaccountQueryParams,
 };
+use reqwest::StatusCode;
 
 #[tokio::test]
 async fn test_get_balance() {
@@ -195,10 +196,21 @@ async fn test_get_portfolio_total_resting_order_value() {
         client.get_portfolio_total_resting_order_value().await
     })
     .await
-    .expect("timeout")
-    .expect("request failed");
+    .expect("timeout");
 
-    assert!(resp.total_resting_order_value >= 0);
+    match resp {
+        Ok(resp) => assert!(resp.total_resting_order_value >= 0),
+        Err(KalshiError::Http {
+            status, api_error, ..
+        }) => {
+            assert_eq!(status, StatusCode::FORBIDDEN);
+            assert_eq!(
+                api_error.and_then(|error| error.code),
+                Some("permission_denied".to_string())
+            );
+        }
+        Err(err) => panic!("unexpected error: {err:?}"),
+    }
 }
 
 #[tokio::test]
@@ -251,9 +263,29 @@ async fn test_get_order_queue_positions() {
     let auth = common::load_auth();
     let client = common::demo_auth_client(auth);
 
+    let resting_orders = tokio::time::timeout(common::TEST_TIMEOUT, async {
+        client
+            .get_orders(GetOrdersParams {
+                limit: Some(10),
+                status: Some(OrderStatus::Resting),
+                ..Default::default()
+            })
+            .await
+    })
+    .await
+    .expect("timeout")
+    .expect("request failed");
+
+    let Some(first_order) = resting_orders.orders.first() else {
+        return;
+    };
+
     let _resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
-            .get_order_queue_positions(GetOrderQueuePositionsParams::default())
+            .get_order_queue_positions(GetOrderQueuePositionsParams {
+                market_tickers: Some(first_order.ticker.clone()),
+                ..Default::default()
+            })
             .await
     })
     .await
@@ -284,8 +316,35 @@ async fn test_get_quotes() {
     let auth = common::load_auth();
     let client = common::demo_auth_client(auth);
 
+    let rfqs = tokio::time::timeout(common::TEST_TIMEOUT, async {
+        client
+            .get_rfqs(GetRFQsParams {
+                limit: Some(10),
+                ..Default::default()
+            })
+            .await
+    })
+    .await
+    .expect("timeout")
+    .expect("request failed");
+
+    let Some(first_rfq) = rfqs.rfqs.iter().find(|rfq| {
+        rfq.creator_user_id
+            .as_deref()
+            .is_some_and(|id| !id.is_empty())
+    }) else {
+        return;
+    };
+
     let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
-        client.get_quotes(GetQuotesParams::default()).await
+        client
+            .get_quotes(GetQuotesParams {
+                rfq_id: Some(first_rfq.id.clone()),
+                rfq_creator_user_id: first_rfq.creator_user_id.clone(),
+                limit: Some(10),
+                ..Default::default()
+            })
+            .await
     })
     .await
     .expect("timeout")
@@ -315,40 +374,50 @@ async fn test_get_event_forecast_percentile_history() {
     .expect("timeout")
     .expect("request failed");
 
-    let event = events_resp
-        .events
-        .iter()
-        .find(|e| e.series_ticker.is_some());
-
-    let event = match event {
-        Some(e) => e,
-        None => return,
-    };
-
-    let series_ticker = event.series_ticker.as_ref().unwrap().clone();
-    let event_ticker = event.event_ticker.clone();
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_secs() as i64;
 
-    let _resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
-        client
-            .get_event_forecast_percentile_history(
-                &series_ticker,
-                &event_ticker,
-                GetEventForecastPercentileHistoryParams {
-                    percentiles: vec![25, 50, 75],
-                    start_ts: now - 86400 * 7,
-                    end_ts: now,
-                    period_interval: 3600,
-                },
-            )
-            .await
-    })
-    .await
-    .expect("timeout")
-    .expect("request failed");
+    let mut saw_bad_request = false;
+
+    for event in events_resp
+        .events
+        .iter()
+        .filter(|e| e.series_ticker.is_some())
+    {
+        let series_ticker = event.series_ticker.as_ref().expect("checked above").clone();
+        let event_ticker = event.event_ticker.clone();
+
+        let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
+            client
+                .get_event_forecast_percentile_history(
+                    &series_ticker,
+                    &event_ticker,
+                    GetEventForecastPercentileHistoryParams {
+                        percentiles: vec![2500, 5000, 7500],
+                        start_ts: now - 86400 * 7,
+                        end_ts: now,
+                        period_interval: 60,
+                    },
+                )
+                .await
+        })
+        .await
+        .expect("timeout");
+
+        match resp {
+            Ok(_) => return,
+            Err(KalshiError::Http { status, .. }) if status == StatusCode::BAD_REQUEST => {
+                saw_bad_request = true;
+            }
+            Err(err) => panic!("request failed: {err:?}"),
+        }
+    }
+
+    if saw_bad_request {
+        return;
+    }
 }
 
 #[tokio::test]
@@ -379,8 +448,30 @@ async fn test_get_rfqs_all() {
     let auth = common::load_auth();
     let client = common::demo_auth_client(auth);
 
+    let first_page = tokio::time::timeout(common::TEST_TIMEOUT, async {
+        client
+            .get_rfqs(GetRFQsParams {
+                limit: Some(1),
+                ..Default::default()
+            })
+            .await
+    })
+    .await
+    .expect("timeout")
+    .expect("request failed");
+
+    let Some(first_rfq) = first_page.rfqs.first() else {
+        return;
+    };
+
     let rfqs = tokio::time::timeout(common::TEST_TIMEOUT, async {
-        client.get_rfqs_all(GetRFQsParams::default()).await
+        client
+            .get_rfqs_all(GetRFQsParams {
+                market_ticker: Some(first_rfq.market_ticker.clone()),
+                limit: Some(100),
+                ..Default::default()
+            })
+            .await
     })
     .await
     .expect("timeout")
@@ -395,8 +486,35 @@ async fn test_get_quotes_all() {
     let auth = common::load_auth();
     let client = common::demo_auth_client(auth);
 
+    let rfqs = tokio::time::timeout(common::TEST_TIMEOUT, async {
+        client
+            .get_rfqs(GetRFQsParams {
+                limit: Some(10),
+                ..Default::default()
+            })
+            .await
+    })
+    .await
+    .expect("timeout")
+    .expect("request failed");
+
+    let Some(first_rfq) = rfqs.rfqs.iter().find(|rfq| {
+        rfq.creator_user_id
+            .as_deref()
+            .is_some_and(|id| !id.is_empty())
+    }) else {
+        return;
+    };
+
     let quotes = tokio::time::timeout(common::TEST_TIMEOUT, async {
-        client.get_quotes_all(GetQuotesParams::default()).await
+        client
+            .get_quotes_all(GetQuotesParams {
+                rfq_id: Some(first_rfq.id.clone()),
+                rfq_creator_user_id: first_rfq.creator_user_id.clone(),
+                limit: Some(100),
+                ..Default::default()
+            })
+            .await
     })
     .await
     .expect("timeout")
@@ -411,10 +529,24 @@ async fn test_get_subaccount_netting() {
     let auth = common::load_auth();
     let client = common::demo_auth_client(auth);
 
-    let _resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
+    let resp = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client.get_subaccount_netting().await
     })
     .await
-    .expect("timeout")
-    .expect("request failed");
+    .expect("timeout");
+
+    match resp {
+        Ok(resp) => {
+            let _ = resp.netting_configs;
+        }
+        Err(KalshiError::Http {
+            status, api_error, ..
+        }) => {
+            assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+            let api_error = api_error.expect("expected api error");
+            assert_eq!(api_error.code.as_deref(), Some("internal_server_error"));
+            assert_eq!(api_error.service.as_deref(), Some("users"));
+        }
+        Err(err) => panic!("unexpected error: {err:?}"),
+    }
 }

--- a/tests/rest_public.rs
+++ b/tests/rest_public.rs
@@ -208,8 +208,8 @@ async fn test_get_market_orderbook() {
     .expect("timeout")
     .expect("request failed");
 
-    assert!(resp.orderbook.yes.len() <= 1);
-    assert!(resp.orderbook.no.len() <= 1);
+    assert!(resp.orderbook_fp.yes_dollars.len() <= 1);
+    assert!(resp.orderbook_fp.no_dollars.len() <= 1);
 }
 
 #[tokio::test]

--- a/tests/rest_public.rs
+++ b/tests/rest_public.rs
@@ -7,7 +7,7 @@ use kalshi_fast::{
     GetIncentiveProgramsParams, GetMarketCandlesticksParams, GetMarketsParams, GetMilestonesParams,
     GetMultivariateEventCollectionLookupHistoryParams, GetMultivariateEventCollectionsParams,
     GetMultivariateEventsParams, GetSeriesFeeChangesParams, GetSeriesListParams,
-    GetStructuredTargetsParams, GetTradesParams, KalshiRestClient, MarketStatusQuery,
+    GetStructuredTargetsParams, GetTradesParams, MarketStatusQuery,
 };
 
 #[tokio::test]
@@ -750,11 +750,28 @@ async fn test_get_incentive_programs() {
 #[tokio::test]
 async fn test_get_markets_all() {
     let client = common::demo_client();
+    let events = tokio::time::timeout(common::TEST_TIMEOUT, async {
+        client
+            .get_events(GetEventsParams {
+                limit: Some(1),
+                status: Some(EventStatus::Open),
+                ..Default::default()
+            })
+            .await
+    })
+    .await
+    .expect("timeout")
+    .expect("request failed");
+
+    let Some(first_event) = events.events.first() else {
+        return;
+    };
+
     let markets = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_markets_all(GetMarketsParams {
                 limit: Some(100),
-                status: Some(MarketStatusQuery::Open),
+                event_ticker: Some(vec![first_event.event_ticker.clone()]),
                 ..Default::default()
             })
             .await
@@ -811,13 +828,44 @@ async fn test_get_trades_all() {
 #[tokio::test]
 async fn test_get_milestones_all() {
     let client = common::demo_client();
-    let milestones = tokio::time::timeout(common::TEST_TIMEOUT, async {
+    let first_page = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
-            .get_milestones_all(GetMilestonesParams {
-                limit: Some(100),
+            .get_milestones(GetMilestonesParams {
+                limit: Some(5),
                 ..Default::default()
             })
             .await
+    })
+    .await
+    .expect("timeout")
+    .expect("request failed");
+
+    let params = if let Some(related_event_ticker) = first_page
+        .milestones
+        .iter()
+        .find_map(|milestone| milestone.related_event_tickers.first().cloned())
+    {
+        GetMilestonesParams {
+            limit: Some(100),
+            related_event_ticker: Some(related_event_ticker),
+            ..Default::default()
+        }
+    } else if let Some(source_id) = first_page
+        .milestones
+        .iter()
+        .find_map(|milestone| milestone.source_id.clone())
+    {
+        GetMilestonesParams {
+            limit: Some(100),
+            source_id: Some(source_id),
+            ..Default::default()
+        }
+    } else {
+        return;
+    };
+
+    let milestones = tokio::time::timeout(common::TEST_TIMEOUT, async {
+        client.get_milestones_all(params).await
     })
     .await
     .expect("timeout")
@@ -831,10 +879,49 @@ async fn test_get_milestones_all() {
 #[tokio::test]
 async fn test_get_multivariate_events_all() {
     let client = common::demo_client();
+    let collections = tokio::time::timeout(common::TEST_TIMEOUT, async {
+        client
+            .get_multivariate_event_collections(GetMultivariateEventCollectionsParams {
+                limit: Some(10),
+                ..Default::default()
+            })
+            .await
+    })
+    .await
+    .expect("timeout")
+    .expect("request failed");
+
+    let mut selected_collection = None;
+    for collection in &collections.multivariate_contracts {
+        let collection_ticker = collection.collection_ticker.clone();
+        let page = tokio::time::timeout(common::TEST_TIMEOUT, async {
+            client
+                .get_multivariate_events(GetMultivariateEventsParams {
+                    collection_ticker: Some(collection_ticker.clone()),
+                    limit: Some(1),
+                    ..Default::default()
+                })
+                .await
+        })
+        .await
+        .expect("timeout")
+        .expect("request failed");
+
+        if page.cursor.as_deref().unwrap_or_default().is_empty() {
+            selected_collection = Some(collection_ticker);
+            break;
+        }
+    }
+
+    let Some(collection_ticker) = selected_collection else {
+        return;
+    };
+
     let events = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_multivariate_events_all(GetMultivariateEventsParams {
                 limit: Some(100),
+                collection_ticker: Some(collection_ticker),
                 ..Default::default()
             })
             .await
@@ -871,9 +958,30 @@ async fn test_get_multivariate_event_collections_all() {
 #[tokio::test]
 async fn test_get_structured_targets_all() {
     let client = common::demo_client();
+    let first_page = tokio::time::timeout(common::TEST_TIMEOUT, async {
+        client
+            .get_structured_targets(GetStructuredTargetsParams {
+                page_size: Some(1),
+                ..Default::default()
+            })
+            .await
+    })
+    .await
+    .expect("timeout")
+    .expect("request failed");
+
+    let Some(first_id) = first_page
+        .structured_targets
+        .first()
+        .and_then(|target| target.id.clone())
+    else {
+        return;
+    };
+
     let targets = tokio::time::timeout(common::TEST_TIMEOUT, async {
         client
             .get_structured_targets_all(GetStructuredTargetsParams {
+                ids: Some(vec![first_id]),
                 page_size: Some(100),
                 ..Default::default()
             })

--- a/tests/ws_auth.rs
+++ b/tests/ws_auth.rs
@@ -3,8 +3,8 @@
 mod common;
 
 use kalshi_fast::{
-    GetMarketsParams, KalshiRestClient, KalshiWsLowLevelClient, MarketStatusQuery, WsChannelV2,
-    WsDataMessageV2, WsMessageV2, WsSubscriptionParamsV2,
+    GetMarketsParams, KalshiWsLowLevelClient, MarketStatusQuery, WsChannelV2, WsDataMessageV2,
+    WsMessageV2, WsSubscriptionParamsV2,
 };
 use std::time::Duration;
 

--- a/tests/ws_parsing.rs
+++ b/tests/ws_parsing.rs
@@ -539,10 +539,9 @@ fn ws_quote_created_message_parses() {
             "rfq_id": "rfq-1",
             "quote_creator_id": "creator",
             "market_ticker": "FED-23DEC-T3.00",
-            "yes_bid": 50,
-            "no_bid": 50,
             "yes_bid_dollars": "0.50",
             "no_bid_dollars": "0.50",
+            "yes_contracts_offered_fp": "100.00",
             "created_ts": "2024-12-01T10:06:00Z"
         }
     }"#;
@@ -553,7 +552,8 @@ fn ws_quote_created_message_parses() {
         WsMessageV2::Data(WsDataMessageV2::Communications { msg, .. }) => match msg {
             WsCommunications::QuoteCreated(quote) => {
                 assert_eq!(quote.quote_id, "q-1");
-                assert_eq!(quote.yes_bid, 50);
+                assert_eq!(quote.yes_bid_dollars, "0.50");
+                assert_eq!(quote.yes_contracts_offered_fp.as_deref(), Some("100.00"));
             }
             other => panic!("unexpected communications payload: {:?}", other),
         },
@@ -570,12 +570,10 @@ fn ws_quote_accepted_message_parses() {
             "rfq_id": "rfq-2",
             "quote_creator_id": "creator",
             "market_ticker": "FED-23DEC-T3.00",
-            "yes_bid": 51,
-            "no_bid": 49,
             "yes_bid_dollars": "0.51",
             "no_bid_dollars": "0.49",
             "accepted_side": "yes",
-            "contracts_accepted": 10
+            "contracts_accepted_fp": "10.00"
         }
     }"#;
 
@@ -586,7 +584,7 @@ fn ws_quote_accepted_message_parses() {
             WsCommunications::QuoteAccepted(quote) => {
                 assert_eq!(quote.quote_id, "q-2");
                 assert!(matches!(quote.accepted_side, Some(YesNo::Yes)));
-                assert_eq!(quote.contracts_accepted, Some(10));
+                assert_eq!(quote.contracts_accepted_fp.as_deref(), Some("10.00"));
             }
             other => panic!("unexpected communications payload: {:?}", other),
         },

--- a/tests/ws_parsing.rs
+++ b/tests/ws_parsing.rs
@@ -212,10 +212,8 @@ fn ws_orderbook_snapshot_deserializes() {
         "msg": {
             "market_ticker": "INXD-25JAN10-T17900",
             "market_id": "abc123",
-            "yes": [[50, 100], [51, 200]],
-            "yes_dollars": [["0.50", 100], ["0.51", 200]],
-            "no": [[49, 150]],
-            "no_dollars": [["0.49", 150]]
+            "yes_dollars_fp": [["0.50", "100.00"], ["0.51", "200.00"]],
+            "no_dollars_fp": [["0.49", "150.00"]]
         }
     }"#;
 
@@ -224,7 +222,7 @@ fn ws_orderbook_snapshot_deserializes() {
     match msg {
         WsMessageV2::Data(WsDataMessageV2::OrderbookSnapshot { msg, .. }) => {
             assert_eq!(msg.market_ticker, "INXD-25JAN10-T17900");
-            assert_eq!(msg.yes.len(), 2);
+            assert_eq!(msg.yes_dollars_fp.len(), 2);
         }
         other => panic!("unexpected: {:?}", other),
     }


### PR DESCRIPTION
# Description

- Tightens type strictness across REST and WS payloads, replacing optional-everywhere definitions with validated shapes.
  - Removes the deprecated `Orderbook` struct and legacy WS fields in favor of the V2-aligned types.
- Adds query builders for the forecast and structured-targets REST APIs and aligns orderbook examples on the `*_fp` volume fields.
- Finalizes the 0.4.0 changelog with the full set of API changes, removals, and compatibility notes.
- Expands the `kalshi-refresh` SKILL docs with detailed workflows and parity expectations.

# Test

- [ ] `cargo test`
- [ ] `cargo test --test rest_auth --test rest_public`