### PR TITLE
[v0.4][7/n] feat(ws): support orderbook get_snapshot and bump to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "kalshi-fast-rs"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kalshi-fast-rs"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "High-performance async Rust client for Kalshi prediction markets API with full WebSocket support"
 license = "MIT"

--- a/src/ws/subscription.rs
+++ b/src/ws/subscription.rs
@@ -90,6 +90,7 @@ impl SubscriptionTracker {
                             *target = None;
                         }
                     }
+                    WsUpdateAction::GetSnapshot => {}
                 }
             };
 
@@ -195,5 +196,32 @@ mod tests {
         );
         assert_eq!(updated.send_initial_snapshot, Some(true));
         assert_eq!(updated.skip_ticker_ack, Some(true));
+    }
+
+    #[test]
+    fn subscription_tracker_get_snapshot_does_not_mutate_targets() {
+        let mut tracker = SubscriptionTracker::default();
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::OrderbookDelta],
+            market_tickers: Some(vec!["A".to_string()]),
+            ..Default::default()
+        };
+        tracker.active.insert(10, params.clone());
+
+        let update = WsUpdateSubscriptionParamsV2 {
+            action: WsUpdateAction::GetSnapshot,
+            sid: Some(10),
+            sids: None,
+            market_ticker: Some("B".to_string()),
+            market_tickers: None,
+            market_id: None,
+            market_ids: None,
+            send_initial_snapshot: None,
+            skip_ticker_ack: None,
+        };
+        tracker.apply_update(&update);
+
+        let updated = tracker.active.get(&10).unwrap();
+        assert_eq!(updated.market_tickers, params.market_tickers);
     }
 }

--- a/src/ws/types/subscription.rs
+++ b/src/ws/types/subscription.rs
@@ -158,11 +158,12 @@ impl WsUpdateSubscriptionParamsV2 {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum WsUpdateAction {
     AddMarkets,
     DeleteMarkets,
+    GetSnapshot,
 }
 
 pub(crate) fn validate_update(params: &WsUpdateSubscriptionParamsV2) -> Result<(), KalshiError> {
@@ -180,6 +181,55 @@ pub(crate) fn validate_update(params: &WsUpdateSubscriptionParamsV2) -> Result<(
             "update_subscription: sids must contain exactly one sid".to_string(),
         ));
     }
+
+    let has_market_ticker = params.market_ticker.is_some();
+    let has_market_tickers = params
+        .market_tickers
+        .as_ref()
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    let has_market_id = params.market_id.is_some();
+    let has_market_ids = params
+        .market_ids
+        .as_ref()
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    let has_any_market_tickers = has_market_ticker || has_market_tickers;
+    let has_any_market_ids = has_market_id || has_market_ids;
+
+    if has_market_ticker && has_market_tickers {
+        return Err(KalshiError::InvalidParams(
+            "update_subscription: provide at most one of market_ticker or market_tickers"
+                .to_string(),
+        ));
+    }
+    if has_market_id && has_market_ids {
+        return Err(KalshiError::InvalidParams(
+            "update_subscription: provide at most one of market_id or market_ids".to_string(),
+        ));
+    }
+    if has_any_market_tickers && has_any_market_ids {
+        return Err(KalshiError::InvalidParams(
+            "update_subscription: market_ticker(s) and market_id(s) are mutually exclusive"
+                .to_string(),
+        ));
+    }
+
+    if params.action == WsUpdateAction::GetSnapshot {
+        if !has_any_market_tickers {
+            return Err(KalshiError::InvalidParams(
+                "update_subscription: get_snapshot requires market_ticker or market_tickers"
+                    .to_string(),
+            ));
+        }
+        if has_any_market_ids {
+            return Err(KalshiError::InvalidParams(
+                "update_subscription: get_snapshot does not support market_id or market_ids"
+                    .to_string(),
+            ));
+        }
+    }
+
     Ok(())
 }
 
@@ -392,6 +442,54 @@ mod tests {
             skip_ticker_ack: None,
         };
         assert!(validate_update(&valid).is_ok());
+    }
+
+    #[test]
+    fn validate_update_get_snapshot_requires_market_target() {
+        let params = WsUpdateSubscriptionParamsV2 {
+            action: WsUpdateAction::GetSnapshot,
+            sid: Some(1),
+            sids: None,
+            market_ticker: None,
+            market_tickers: None,
+            market_id: None,
+            market_ids: None,
+            send_initial_snapshot: None,
+            skip_ticker_ack: None,
+        };
+        assert!(validate_update(&params).is_err());
+    }
+
+    #[test]
+    fn validate_update_get_snapshot_rejects_market_ids() {
+        let params = WsUpdateSubscriptionParamsV2 {
+            action: WsUpdateAction::GetSnapshot,
+            sid: Some(1),
+            sids: None,
+            market_ticker: Some("TICKER".to_string()),
+            market_tickers: None,
+            market_id: Some("uuid".to_string()),
+            market_ids: None,
+            send_initial_snapshot: None,
+            skip_ticker_ack: None,
+        };
+        assert!(validate_update(&params).is_err());
+    }
+
+    #[test]
+    fn validate_update_get_snapshot_accepts_market_tickers() {
+        let params = WsUpdateSubscriptionParamsV2 {
+            action: WsUpdateAction::GetSnapshot,
+            sid: Some(1),
+            sids: None,
+            market_ticker: None,
+            market_tickers: Some(vec!["TICKER".to_string()]),
+            market_id: None,
+            market_ids: None,
+            send_initial_snapshot: None,
+            skip_ticker_ack: None,
+        };
+        assert!(validate_update(&params).is_ok());
     }
 
     #[test]

--- a/tests/ws_get_snapshot.rs
+++ b/tests/ws_get_snapshot.rs
@@ -1,0 +1,130 @@
+#![cfg(feature = "live-tests")]
+
+mod common;
+
+use kalshi_fast::{
+    WsChannelV2, WsDataMessageV2, WsMessageV2, WsSubscriptionParamsV2, WsUpdateAction,
+    WsUpdateSubscriptionParamsV2,
+};
+
+#[tokio::test]
+async fn ws_demo_orderbook_get_snapshot_returns_snapshot_without_mutating_subscription() {
+    let market_ticker = common::first_open_demo_market_ticker().await;
+    let mut ws = common::connect_demo_ws().await;
+
+    let subscribe_id = ws
+        .subscribe_v2(WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::OrderbookDelta],
+            market_ticker: Some(market_ticker.clone()),
+            ..Default::default()
+        })
+        .await
+        .expect("orderbook subscribe failed");
+
+    let sid = common::wait_for_subscribed(&mut ws, subscribe_id).await;
+
+    // Drain until we see the first orderbook message so the subscription is live.
+    let initial = common::wait_for_message(&mut ws, common::CHANNEL_TIMEOUT, |msg| {
+        matches!(
+            msg,
+            WsMessageV2::Data(WsDataMessageV2::OrderbookDelta { .. })
+                | WsMessageV2::Data(WsDataMessageV2::OrderbookSnapshot { .. })
+        )
+    })
+    .await;
+
+    match initial {
+        WsMessageV2::Data(WsDataMessageV2::OrderbookDelta {
+            sid: msg_sid, msg, ..
+        }) => {
+            assert_eq!(msg_sid, Some(sid));
+            assert_eq!(msg.market_ticker, market_ticker);
+        }
+        WsMessageV2::Data(WsDataMessageV2::OrderbookSnapshot {
+            sid: msg_sid, msg, ..
+        }) => {
+            assert_eq!(msg_sid, Some(sid));
+            assert_eq!(msg.market_ticker, market_ticker);
+        }
+        other => panic!("unexpected initial orderbook message: {other:?}"),
+    }
+
+    let update_id = ws
+        .update_subscription_v2(WsUpdateSubscriptionParamsV2 {
+            action: WsUpdateAction::GetSnapshot,
+            sid: Some(sid),
+            sids: None,
+            market_ticker: Some(market_ticker.clone()),
+            market_tickers: None,
+            market_id: None,
+            market_ids: None,
+            send_initial_snapshot: None,
+            skip_ticker_ack: None,
+        })
+        .await
+        .expect("get_snapshot update failed");
+
+    let snapshot = common::wait_for_message(&mut ws, common::CHANNEL_TIMEOUT, |msg| {
+        matches!(
+            msg,
+            WsMessageV2::Data(WsDataMessageV2::OrderbookSnapshot {
+                sid: Some(msg_sid),
+                msg,
+                ..
+            }) if *msg_sid == sid && msg.market_ticker == market_ticker
+        )
+    })
+    .await;
+
+    match snapshot {
+        WsMessageV2::Data(WsDataMessageV2::OrderbookSnapshot {
+            sid: msg_sid, msg, ..
+        }) => {
+            assert_eq!(msg_sid, Some(sid));
+            assert_eq!(msg.market_ticker, market_ticker);
+            assert!(!msg.market_id.is_empty());
+            assert!(
+                msg.yes_dollars_fp
+                    .iter()
+                    .all(|(p, q)| !p.is_empty() && !q.is_empty())
+            );
+            assert!(
+                msg.no_dollars_fp
+                    .iter()
+                    .all(|(p, q)| !p.is_empty() && !q.is_empty())
+            );
+        }
+        other => panic!("expected orderbook_snapshot after get_snapshot, got {other:?}"),
+    }
+
+    let list_id = ws
+        .list_subscriptions()
+        .await
+        .expect("list_subscriptions failed after get_snapshot");
+
+    let listed = common::wait_for_message(
+        &mut ws,
+        common::CHANNEL_TIMEOUT,
+        |msg| matches!(msg, WsMessageV2::ListSubscriptions { id: Some(id), .. } if *id == list_id),
+    )
+    .await;
+
+    match listed {
+        WsMessageV2::ListSubscriptions { subscriptions, .. } => {
+            let subscription = subscriptions
+                .into_iter()
+                .find(|sub| sub.sid == sid)
+                .expect("subscription missing after get_snapshot");
+            assert!(
+                subscription.channels.contains(&WsChannelV2::OrderbookDelta)
+                    || subscription.channel == Some(WsChannelV2::OrderbookDelta)
+            );
+            if let Some(market_tickers) = subscription.market_tickers {
+                assert_eq!(market_tickers, vec![market_ticker]);
+            }
+        }
+        other => panic!("expected list_subscriptions response, got {other:?}"),
+    }
+
+    assert!(update_id > 0);
+}


### PR DESCRIPTION
# Description

- Adds first-class support for the WebSocket `get_snapshot` orderbook command, extending the subscription API with a snapshot request path and the matching parsed snapshot update type.
  - Includes a `ws_get_snapshot` integration test covering the request/response round-trip.
- Bumps the crate to `0.4.1` to cover the additive WS surface.

# Test

- [ ] `cargo test --test ws_get_snapshot`
- [ ] `cargo test`