### PR TITLE
Keep get_snapshot subscription updates non-mutating

### DIFF
--- a/src/ws/subscription.rs
+++ b/src/ws/subscription.rs
@@ -75,9 +75,10 @@ impl SubscriptionTracker {
                 if incoming.is_empty() {
                     return;
                 }
-                let values = target.get_or_insert_with(Vec::new);
+
                 match action {
                     WsUpdateAction::AddMarkets => {
+                        let values = target.get_or_insert_with(Vec::new);
                         for value in incoming {
                             if !values.iter().any(|v| v == &value) {
                                 values.push(value);
@@ -85,6 +86,9 @@ impl SubscriptionTracker {
                         }
                     }
                     WsUpdateAction::DeleteMarkets => {
+                        let Some(values) = target.as_mut() else {
+                            return;
+                        };
                         values.retain(|current| !incoming.iter().any(|value| value == current));
                         if values.is_empty() {
                             *target = None;
@@ -196,6 +200,36 @@ mod tests {
         );
         assert_eq!(updated.send_initial_snapshot, Some(true));
         assert_eq!(updated.skip_ticker_ack, Some(true));
+    }
+
+    #[test]
+    fn subscription_tracker_get_snapshot_preserves_absent_plural_targets() {
+        let mut tracker = SubscriptionTracker::default();
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::OrderbookDelta],
+            market_ticker: Some("A".to_string()),
+            market_tickers: None,
+            market_id: Some("ID-A".to_string()),
+            market_ids: None,
+            ..Default::default()
+        };
+        tracker.active.insert(10, params.clone());
+
+        let update = WsUpdateSubscriptionParamsV2 {
+            action: WsUpdateAction::GetSnapshot,
+            sid: Some(10),
+            sids: None,
+            market_ticker: Some("B".to_string()),
+            market_tickers: None,
+            market_id: None,
+            market_ids: None,
+            send_initial_snapshot: None,
+            skip_ticker_ack: None,
+        };
+        tracker.apply_update(&update);
+
+        let updated = tracker.active.get(&10).unwrap();
+        assert_eq!(updated, &params);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- `GetSnapshot` updates were materializing empty plural target vectors (via `get_or_insert_with`) when the tracker held targets in singular fields, which mutates tracker state for a nominally non-mutating action.
- Delete updates could also materialize absent plural vectors; both behaviors change resubscribe payloads after reconnect and are undesirable.

### Description
- Modify `apply_vec` in `src/ws/subscription.rs` to only call `get_or_insert_with` inside the `AddMarkets` branch and to return early for `DeleteMarkets` when the plural target is absent, leaving `GetSnapshot` as a true no-op.
- Add a regression test `subscription_tracker_get_snapshot_preserves_absent_plural_targets` to verify a `GetSnapshot` against a subscription with singular targets and absent plural targets does not mutate the tracked params.
- Update is limited to `src/ws/subscription.rs` and its inline unit tests.

### Testing
- Ran `cargo fmt` and formatting check succeeded.
- Ran `cargo test subscription_tracker_get_snapshot --lib` and the new/related tests passed.
- Ran `cargo test validate_update_get_snapshot --lib` and the validation tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c03b2729c8320a5b82ac204e78d37)