### PR TITLE
Add V2 event-order endpoints, CF Benchmarks channel, and API rate-limit restructuring

### DIFF
--- a/.claude/skills/kalshi-api-docs/references/GOTCHAS.md
+++ b/.claude/skills/kalshi-api-docs/references/GOTCHAS.md
@@ -9,8 +9,12 @@ This applies to WebSockets.
 
 ## Multiple URLs Exist
 
-- Live REST root: `https://api.elections.kalshi.com/trade-api/v2`
-- Live WebSocket root: `wss://api.elections.kalshi.com/trade-api/ws/v2`
-- Demo REST root: `https://demo-api.kalshi.co/trade-api/v2`
-- Demo WebSocket root: `wss://demo-api.kalshi.co/trade-api/ws/v2`
+The external API hosts were introduced on 2026-05-07. Use these:
+
+- Live REST root: `https://external-api.kalshi.com/trade-api/v2`
+- Live WebSocket root: `wss://external-api-ws.kalshi.com/trade-api/ws/v2`
+- Demo REST root: `https://external-api.demo.kalshi.co/trade-api/v2`
+- Demo WebSocket root: `wss://external-api-ws.demo.kalshi.co/trade-api/ws/v2`
 - Demo credentials are separate from live credentials.
+
+The old hosts (`api.elections.kalshi.com`, `demo-api.kalshi.co`) are no longer used as of 0.5.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ For crate versioning policy and bump rules, see [`VERSIONING.md`](VERSIONING.md)
 | Margin fee-tier returns active rates (2026-06-03/11) | No code change — exchange bug fix only |
 | Perps volume/OI notional fields on margin markets (2026-06-05/11) | No code change — margin market types not in crate |
 | Tick size on `GET /margin/markets` (2026-06-03/11) | No code change — margin market types not in crate |
-| Automated API rate-limit tiers / grants (2026-06-06/11) | **Breaking** — replaced `GetAccountApiLimitsResponse`; added `BucketLimit`, `ApiUsageLevelGrant` |
+| Automated API rate-limit tiers / grants (2026-06-06) | **Breaking** — replaced `GetAccountApiLimitsResponse`; added `BucketLimit`, `ApiUsageLevelGrant`; added `GET /account/endpoint_costs` (`get_account_endpoint_costs`, `GetAccountEndpointCostsResponse`, `EndpointTokenCost`) |
 | Fractional contract quantities for RFQs (2026-05-26/2026-06-11) | No code change — `contracts_fp` already present in `CreateRfqRequest` |
 | Legacy order endpoints cost 10× rate-limit tokens (2026-06-04) | No code change — operational rate-limit change only |
 | Post Only Cross Cancel `last_update_reason` value (2026-06-04) | No code change — `last_update_reason` not modeled in `Order`; tolerated by existing `extra` flatten if present |
@@ -53,6 +53,15 @@ For crate versioning policy and bump rules, see [`VERSIONING.md`](VERSIONING.md)
 - [Rust API] Added `BucketLimit` and `ApiUsageLevelGrant` structs (2026-06-06). `BucketLimit` holds
   `refill_rate: i64` and `bucket_capacity: i64`. `ApiUsageLevelGrant` holds `exchange_instance`,
   `level`, `source: String`, and `expires_ts: Option<i64>` (absent for non-expiring grants).
+- [Rust API] Added `get_account_endpoint_costs()` method and `GetAccountEndpointCostsResponse` /
+  `EndpointTokenCost` structs for the new public `GET /account/endpoint_costs` endpoint, which lists
+  API v2 endpoints whose token cost differs from the default cost.
+- [Rust API] Added CF Benchmarks subscription-update support so the documented post-subscribe
+  workflow is reachable: `WsUpdateAction::SubscribeIndices` / `UnsubscribeIndices` / `Indexlist`
+  variants and an `index_ids: Option<Vec<String>>` field on `WsUpdateSubscriptionParamsV2`. The
+  subscription tracker now folds index add/remove updates into the resubscribe state, and
+  `validate_update` enforces that index actions carry no market targets and that
+  `subscribe_indices` / `unsubscribe_indices` include `index_ids`.
 - [Rust API] Added `FeeType::QuadraticWithMakerFees` variant (serialized
   `quadratic_with_maker_fees`). `FeeType` now also carries an `#[serde(other)] Unknown` catch-all
   so unknown future variants never panic.
@@ -78,6 +87,10 @@ For crate versioning policy and bump rules, see [`VERSIONING.md`](VERSIONING.md)
   2026-06-06). Replace `resp.read_limit` → `resp.read.refill_rate` (or `.bucket_capacity`) and
   `resp.write_limit` → `resp.write.refill_rate`. The `grants` field is new; downstream exhaustive
   struct destructuring must add it.
+- [Rust API] `WsUpdateAction` gained `SubscribeIndices`, `UnsubscribeIndices`, and `Indexlist`
+  variants, and `WsUpdateSubscriptionParamsV2` gained an `index_ids` field. Downstream code with
+  exhaustive matches over `WsUpdateAction` or struct-literal construction of
+  `WsUpdateSubscriptionParamsV2` must be updated.
 
 
 ## [0.5.0] - 2026-05-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,78 @@ Kalshi docs snapshot tracked by that release.
 For crate versioning policy and bump rules, see [`VERSIONING.md`](VERSIONING.md).
 
 
+## [0.6.0] - 2026-06-08
+
+### Compatibility
+
+- Docs snapshot: 2026-06-08
+- OpenAPI: 3.20.0
+- AsyncAPI: 2.0.0
+- Validated through changelog: 2026-06-08
+
+**Changelog entries since 0.5.0 watermark (2026-06-04) and disposition:**
+
+| Entry | Action |
+|---|---|
+| Margin fee-tier returns active rates (2026-06-03/11) | No code change — exchange bug fix only |
+| Perps volume/OI notional fields on margin markets (2026-06-05/11) | No code change — margin market types not in crate |
+| Tick size on `GET /margin/markets` (2026-06-03/11) | No code change — margin market types not in crate |
+| Automated API rate-limit tiers / grants (2026-06-06/11) | **Breaking** — replaced `GetAccountApiLimitsResponse`; added `BucketLimit`, `ApiUsageLevelGrant` |
+| Fractional contract quantities for RFQs (2026-05-26/2026-06-11) | No code change — `contracts_fp` already present in `CreateRfqRequest` |
+| Legacy order endpoints cost 10× rate-limit tokens (2026-06-04) | No code change — operational rate-limit change only |
+| Post Only Cross Cancel `last_update_reason` value (2026-06-04) | No code change — `last_update_reason` not modeled in `Order`; tolerated by existing `extra` flatten if present |
+| Transfer-scoped API key permissions (2026-06-03) | No code change — scopes stored as `Vec<String>` already |
+| Block trade indicators on public trade endpoints (2026-05-29/2026-06-01) | Added `is_block_trade` to `Trade` and `GetTradesParams` |
+| V2 event-order endpoints (`/portfolio/events/orders/*`) | Added all V2 types and six new `KalshiRestClient` methods |
+| `cfbenchmarks_value` AsyncAPI channel | Added full channel, subscription, and message support |
+| `FeeType::quadratic_with_maker_fees` | Added `QuadraticWithMakerFees` variant to `FeeType` enum |
+
+### Added
+
+- [Rust API] Added `is_block_trade: bool` (with `#[serde(default)]`) to the public REST `Trade`
+  struct (2026-05-29). Defaults to `false` for payloads predating the flag.
+- [Rust API] Added `is_block_trade: Option<bool>` filter to `GetTradesParams` so callers can filter
+  by block-trade status on `GET /markets/trades` and `GET /historical/trades`.
+- [Rust API] Added all V2 event-order types and six new `KalshiRestClient` methods for the lower-cost
+  `/portfolio/events/orders/*` endpoints: `create_order_v2`, `cancel_order_v2`, `amend_order_v2`,
+  `decrease_order_v2`, `batch_create_orders_v2`, `batch_cancel_orders_v2`. These endpoints use a
+  single price + `BookSide` instead of separate yes/no prices.
+  New request/response types: `CreateOrderV2Request`, `CreateOrderV2Response`,
+  `CancelOrderV2Params`, `CancelOrderV2Response`, `AmendOrderV2Request`, `AmendOrderV2Response`,
+  `DecreaseOrderV2Request`, `DecreaseOrderV2Response`, `BatchCreateOrdersV2Request`,
+  `BatchCreateOrderV2OrderResponse`, `BatchCreateOrdersV2Response`,
+  `BatchCancelOrderV2RequestOrder`, `BatchCancelOrdersV2Request`,
+  `BatchCancelOrderV2OrderResponse`, `BatchCancelOrdersV2Response`.
+- [Rust API] Added `BucketLimit` and `ApiUsageLevelGrant` structs (2026-06-06). `BucketLimit` holds
+  `refill_rate: i64` and `bucket_capacity: i64`. `ApiUsageLevelGrant` holds `exchange_instance`,
+  `level`, `source: String`, and `expires_ts: Option<i64>` (absent for non-expiring grants).
+- [Rust API] Added `FeeType::QuadraticWithMakerFees` variant (serialized
+  `quadratic_with_maker_fees`). `FeeType` now also carries an `#[serde(other)] Unknown` catch-all
+  so unknown future variants never panic.
+- [Rust API] Added full `cfbenchmarks_value` channel support:
+  - `WsChannelV2::CfbenchmarksValue` variant
+  - `index_ids: Option<Vec<String>>` parameter on `WsSubscriptionParamsV2` (use `["all"]` for all
+    indices)
+  - `WsMsgType::CfbenchmarksValue` and `WsMsgType::CfbenchmarksValueIndexlist` variants
+  - New types `WsCfBenchmarksValue`, `WsCfBenchmarksValueRef`, `WsCfBenchmarksAvgData`,
+    `WsCfBenchmarksIndexList`, `WsCfBenchmarksIndexListRef` in `ws::types::messages::cfbenchmarks`
+  - `WsDataMessageV2::CfbenchmarksValue` and `WsDataMessageV2::CfbenchmarksValueIndexlist` variants
+    routed through both the wire and envelope parse paths
+
+### Changed
+
+- [Rust API] `GetAccountApiLimitsResponse` now reflects the current OpenAPI shape: nested
+  `read: BucketLimit` and `write: BucketLimit` objects plus `grants: Vec<ApiUsageLevelGrant>`.
+  The old flat `read_limit: i64` / `write_limit: i64` fields are removed.
+
+### Breaking
+
+- [Rust API] `GetAccountApiLimitsResponse` field layout changed (automated API rate-limit tiers,
+  2026-06-06). Replace `resp.read_limit` → `resp.read.refill_rate` (or `.bucket_capacity`) and
+  `resp.write_limit` → `resp.write.refill_rate`. The `grants` field is new; downstream exhaustive
+  struct destructuring must add it.
+
+
 ## [0.5.0] - 2026-05-29
 
 ### Compatibility

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "kalshi-fast-rs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kalshi-fast-rs"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 description = "High-performance async Rust client for Kalshi prediction markets API with full WebSocket support"
 license = "MIT"

--- a/docs/spec-parity.md
+++ b/docs/spec-parity.md
@@ -47,9 +47,35 @@ examples are ambiguous.
 
 - `event_fee_update` is an AsyncAPI message delivered on the `market_lifecycle_v2` channel (it is
   not a separately-subscribable channel). It is modeled by `WsEventFeeUpdate`. `fee_type_override`
-  is kept as `Option<String>` rather than reusing the `FeeType` enum, because the spec includes a
-  `quadratic_with_maker_fees` variant not present in `FeeType` and the field must stay lossless for
-  fee math. Both override fields are nullable (`None` when the override is cleared).
+  is kept as `Option<String>` rather than reusing the `FeeType` enum so the raw string survives any
+  future fee-type additions without a crate update. Both override fields are nullable (`None` when
+  the override is cleared).
+
+- `FeeType` enum now includes `QuadraticWithMakerFees` (serialized `quadratic_with_maker_fees`),
+  added to the OpenAPI spec in 2026. An `#[serde(other)] Unknown` catch-all is also present so
+  unrecognised future variants never panic during deserialization. `fee_type_override` on
+  `WsEventFeeUpdate` remains `Option<String>` for lossless round-trip regardless.
+
+- `is_block_trade: bool` was added to the public REST `Trade` struct (2026-05-29). The field is
+  `#[serde(default)]` (defaults to `false`) so payloads predating the flag still parse. The query
+  filter `GetTradesParams::is_block_trade: Option<bool>` lets callers filter by block-trade status.
+
+- `GET /account/limits` (`get_account_api_limits`) response was restructured in 2026-06 (automated
+  API rate-limit tiers). The old flat shape (`read_limit: i64, write_limit: i64`) was replaced by
+  nested `BucketLimit` objects (`read: BucketLimit, write: BucketLimit`) plus a `grants:
+  Vec<ApiUsageLevelGrant>` array. The `GetAccountApiLimitsResponse` struct was updated accordingly;
+  old field access will not compile (intentional minor-version break, 0.5.0 → 0.6.0).
+  `ApiUsageLevelGrant.expires_ts` is `Option<i64>` because the field is absent for non-expiring
+  grants.
+
+- `cfbenchmarks_value` is a new AsyncAPI channel (introduced 2026-06) that delivers CF Benchmarks
+  index values. It uses `index_ids` (not market tickers) for subscription parameters; pass
+  `["all"]` to receive all available indices. The channel emits two message types:
+  `cfbenchmarks_value` (per-index value + 60-second windowed average) and
+  `cfbenchmarks_value_indexlist` (the full set of available index IDs). Both are modeled as
+  `WsCfBenchmarksValue` / `WsCfBenchmarksIndexList` and routed through the standard
+  `WsDataMessageV2` enum. `last_60s_windowed_average_15min` on `WsCfBenchmarksValue` is `Option`
+  because the spec marks it conditional.
 - The AsyncAPI marks several timestamp/required fields that the exchange may omit in practice
   (`ts_ms` on ticker/trade/order-group messages, the legacy direction fields). These are modeled as
   `Option` so parsing never fails on their absence.

--- a/docs/spec-parity.md
+++ b/docs/spec-parity.md
@@ -75,7 +75,18 @@ examples are ambiguous.
   `cfbenchmarks_value_indexlist` (the full set of available index IDs). Both are modeled as
   `WsCfBenchmarksValue` / `WsCfBenchmarksIndexList` and routed through the standard
   `WsDataMessageV2` enum. `last_60s_windowed_average_15min` on `WsCfBenchmarksValue` is `Option`
-  because the spec marks it conditional.
+  because the spec marks it conditional. The documented post-subscribe workflow (discover indices
+  via `indexlist`, then add/remove with `subscribe_indices` / `unsubscribe_indices`) is supported
+  through `update_subscription_v2` using the `WsUpdateAction::SubscribeIndices` /
+  `UnsubscribeIndices` / `Indexlist` actions plus the `index_ids` field on
+  `WsUpdateSubscriptionParamsV2`. `validate_update` rejects mixing index actions with market targets
+  and requires `index_ids` for the add/remove actions, matching the AsyncAPI error semantics.
+
+- `GET /account/endpoint_costs` (`get_account_endpoint_costs`) is modeled as a public (unauthed)
+  endpoint because the OpenAPI operation declares no `security` requirement, unlike `/account/limits`.
+  `ApiUsageLevelGrant.exchange_instance` is kept as `String` rather than an `ExchangeInstance` enum
+  (`event_contract` | `margined`); the raw string round-trips losslessly and tolerates any future
+  exchange-instance values without a crate update.
 - The AsyncAPI marks several timestamp/required fields that the exchange may omit in practice
   (`ts_ms` on ticker/trade/order-group messages, the legacy direction fields). These are modeled as
   `Option` so parsing never fails on their absence.

--- a/examples/ws_user_orders.rs
+++ b/examples/ws_user_orders.rs
@@ -44,6 +44,7 @@ async fn main() -> anyhow::Result<()> {
                         market_ids: None,
                         send_initial_snapshot: None,
                         skip_ticker_ack: None,
+                        index_ids: None,
                     })
                     .await;
             }

--- a/src/rest/account.rs
+++ b/src/rest/account.rs
@@ -43,8 +43,32 @@ pub struct GetAccountApiLimitsResponse {
     pub usage_tier: String,
     pub read: BucketLimit,
     pub write: BucketLimit,
-    /// Active usage-level grants across exchange lanes. Added 2026-06-11.
+    /// Active usage-level grants across exchange lanes. Added 2026-06-06
+    /// (automated API rate-limit tiers). Tolerates a missing/`null` array.
+    #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
     pub grants: Vec<ApiUsageLevelGrant>,
+}
+
+/// Token cost for one API v2 endpoint whose cost differs from the default.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EndpointTokenCost {
+    /// HTTP method for the endpoint.
+    pub method: String,
+    /// API route path for the endpoint.
+    pub path: String,
+    /// Configured token cost for this endpoint.
+    pub cost: i64,
+}
+
+/// Response for `GET /account/endpoint_costs`. Lists only endpoints whose
+/// configured token cost differs from `default_cost`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GetAccountEndpointCostsResponse {
+    /// Default token cost applied to endpoints not listed in `endpoint_costs`.
+    pub default_cost: i64,
+    /// Endpoints whose cost differs from the default.
+    #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
+    pub endpoint_costs: Vec<EndpointTokenCost>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -198,6 +222,23 @@ impl KalshiRestClient {
             Option::<&()>::None,
             Option::<&()>::None,
             true,
+        )
+        .await
+    }
+
+    /// List API v2 endpoints whose token cost differs from the default cost.
+    ///
+    /// Public endpoint (no auth required per the OpenAPI spec).
+    pub async fn get_account_endpoint_costs(
+        &self,
+    ) -> Result<GetAccountEndpointCostsResponse, KalshiError> {
+        let path = Self::full_path("/account/endpoint_costs");
+        self.send(
+            Method::GET,
+            &path,
+            Option::<&()>::None,
+            Option::<&()>::None,
+            false,
         )
         .await
     }

--- a/src/rest/account.rs
+++ b/src/rest/account.rs
@@ -15,11 +15,36 @@ use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
+/// Token-bucket rate-limit configuration for one endpoint group.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BucketLimit {
+    /// Tokens added to the bucket per second.
+    pub refill_rate: i64,
+    /// Maximum tokens the bucket can hold.
+    pub bucket_capacity: i64,
+}
+
+/// An active API usage-level grant (earned via volume or granted manually).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ApiUsageLevelGrant {
+    /// Exchange instance this grant applies to (`"event_contract"` or `"margined"`).
+    pub exchange_instance: String,
+    /// Usage level this grant confers (e.g. `"premier"`, `"paragon"`, `"prime"`).
+    pub level: String,
+    /// Unix timestamp (seconds) when the grant expires; `None` for permanent grants.
+    #[serde(default)]
+    pub expires_ts: Option<i64>,
+    /// How the grant was created: `"volume"` or `"manual"`.
+    pub source: String,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GetAccountApiLimitsResponse {
     pub usage_tier: String,
-    pub read_limit: i64,
-    pub write_limit: i64,
+    pub read: BucketLimit,
+    pub write: BucketLimit,
+    /// Active usage-level grants across exchange lanes. Added 2026-06-11.
+    pub grants: Vec<ApiUsageLevelGrant>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/rest/orders.rs
+++ b/src/rest/orders.rs
@@ -503,6 +503,192 @@ pub struct BatchCancelOrdersIndividualResponse {
 pub type GetFcmOrdersResponse = GetOrdersResponse;
 pub type GetFcmPositionsResponse = GetPositionsResponse;
 
+// ---------------------------------------------------------------------------
+// V2 event-order endpoints  (/portfolio/events/orders/*)
+// ---------------------------------------------------------------------------
+
+/// Create Order (V2) body. Uses `BookSide` + single fixed-point price.
+///
+/// Required: `ticker`, `side`, `count`, `price`, `time_in_force`, `self_trade_prevention_type`.
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateOrderV2Request {
+    pub ticker: String,
+    pub side: BookSide,
+    pub count: FixedPointCount,
+    pub price: FixedPointDollars,
+    pub time_in_force: TimeInForce,
+    pub self_trade_prevention_type: SelfTradePreventionType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_order_id: Option<String>,
+    /// Unix seconds; combine with `time_in_force: good_till_canceled` for GTT.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiration_time: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_only: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancel_order_on_pause: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reduce_only: Option<bool>,
+    /// 0 = primary; 1–32 = subaccount.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subaccount: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_group_id: Option<String>,
+    /// Exchange shard index; currently only 0 is supported.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exchange_index: Option<u32>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CreateOrderV2Response {
+    pub order_id: String,
+    #[serde(default)]
+    pub client_order_id: Option<String>,
+    pub fill_count: FixedPointCount,
+    pub remaining_count: FixedPointCount,
+    #[serde(default)]
+    pub average_fill_price: Option<FixedPointDollars>,
+    #[serde(default)]
+    pub average_fee_paid: Option<FixedPointDollars>,
+    pub ts_ms: i64,
+}
+
+/// Query params for Cancel Order (V2).
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct CancelOrderV2Params {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subaccount: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exchange_index: Option<u32>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CancelOrderV2Response {
+    pub order_id: String,
+    #[serde(default)]
+    pub client_order_id: Option<String>,
+    pub reduced_by: FixedPointCount,
+    pub ts_ms: i64,
+}
+
+/// Amend Order (V2) body. Uses `BookSide` + single fixed-point price.
+///
+/// Required: `ticker`, `side`, `price`, `count`.
+#[derive(Debug, Clone, Serialize)]
+pub struct AmendOrderV2Request {
+    pub ticker: String,
+    pub side: BookSide,
+    pub price: FixedPointDollars,
+    pub count: FixedPointCount,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_order_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_client_order_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exchange_index: Option<u32>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AmendOrderV2Response {
+    pub order_id: String,
+    #[serde(default)]
+    pub client_order_id: Option<String>,
+    #[serde(default)]
+    pub remaining_count: Option<FixedPointCount>,
+    #[serde(default)]
+    pub fill_count: Option<FixedPointCount>,
+    #[serde(default)]
+    pub average_fill_price: Option<FixedPointDollars>,
+    #[serde(default)]
+    pub average_fee_paid: Option<FixedPointDollars>,
+    pub ts_ms: i64,
+}
+
+/// Decrease Order (V2) body. Fixed-point strings only; no integer variants.
+///
+/// Exactly one of `reduce_by` or `reduce_to` must be provided.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct DecreaseOrderV2Request {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reduce_by: Option<FixedPointCount>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reduce_to: Option<FixedPointCount>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exchange_index: Option<u32>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DecreaseOrderV2Response {
+    pub order_id: String,
+    #[serde(default)]
+    pub client_order_id: Option<String>,
+    pub remaining_count: FixedPointCount,
+    pub ts_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchCreateOrdersV2Request {
+    pub orders: Vec<CreateOrderV2Request>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BatchCreateOrderV2OrderResponse {
+    #[serde(default)]
+    pub order_id: Option<String>,
+    #[serde(default)]
+    pub client_order_id: Option<String>,
+    #[serde(default)]
+    pub fill_count: Option<FixedPointCount>,
+    #[serde(default)]
+    pub remaining_count: Option<FixedPointCount>,
+    #[serde(default)]
+    pub average_fill_price: Option<FixedPointDollars>,
+    #[serde(default)]
+    pub average_fee_paid: Option<FixedPointDollars>,
+    #[serde(default)]
+    pub ts_ms: Option<i64>,
+    #[serde(default)]
+    pub error: Option<ErrorResponse>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BatchCreateOrdersV2Response {
+    #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
+    pub orders: Vec<BatchCreateOrderV2OrderResponse>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchCancelOrderV2RequestOrder {
+    pub order_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subaccount: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exchange_index: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BatchCancelOrdersV2Request {
+    pub orders: Vec<BatchCancelOrderV2RequestOrder>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BatchCancelOrderV2OrderResponse {
+    pub order_id: String,
+    #[serde(default)]
+    pub client_order_id: Option<String>,
+    pub reduced_by: FixedPointCount,
+    #[serde(default)]
+    pub ts_ms: Option<i64>,
+    #[serde(default)]
+    pub error: Option<ErrorResponse>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BatchCancelOrdersV2Response {
+    #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
+    pub orders: Vec<BatchCancelOrderV2OrderResponse>,
+}
+
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct GetFcmOrdersParams {
     pub subtrader_id: String,
@@ -740,6 +926,101 @@ impl KalshiRestClient {
         let body = EmptyResponse::default();
         self.send(Method::PUT, &path, Some(&params), Some(&body), true)
             .await
+    }
+
+    // --- V2 event-order endpoints ---
+
+    /// Place a new order via the V2 event-order endpoint.
+    ///
+    /// Uses `BookSide` + single fixed-point `price`. Lower rate-limit cost than legacy.
+    ///
+    /// **Requires auth.**
+    pub async fn create_order_v2(
+        &self,
+        body: CreateOrderV2Request,
+    ) -> Result<CreateOrderV2Response, KalshiError> {
+        let path = Self::full_path("/portfolio/events/orders");
+        self.send(Method::POST, &path, Option::<&()>::None, Some(&body), true)
+            .await
+    }
+
+    /// Cancel an order via the V2 event-order endpoint.
+    ///
+    /// **Requires auth.**
+    pub async fn cancel_order_v2(
+        &self,
+        order_id: &str,
+        params: CancelOrderV2Params,
+    ) -> Result<CancelOrderV2Response, KalshiError> {
+        let path = Self::full_path(&format!("/portfolio/events/orders/{order_id}"));
+        self.send(
+            Method::DELETE,
+            &path,
+            Some(&params),
+            Option::<&()>::None,
+            true,
+        )
+        .await
+    }
+
+    /// Amend an order via the V2 event-order endpoint.
+    ///
+    /// **Requires auth.**
+    pub async fn amend_order_v2(
+        &self,
+        order_id: &str,
+        params: SubaccountQueryParams,
+        body: AmendOrderV2Request,
+    ) -> Result<AmendOrderV2Response, KalshiError> {
+        let path = Self::full_path(&format!("/portfolio/events/orders/{order_id}/amend"));
+        self.send(Method::POST, &path, Some(&params), Some(&body), true)
+            .await
+    }
+
+    /// Decrease an order via the V2 event-order endpoint.
+    ///
+    /// Provide exactly one of `reduce_by` or `reduce_to` in the body.
+    ///
+    /// **Requires auth.**
+    pub async fn decrease_order_v2(
+        &self,
+        order_id: &str,
+        params: SubaccountQueryParams,
+        body: DecreaseOrderV2Request,
+    ) -> Result<DecreaseOrderV2Response, KalshiError> {
+        let path = Self::full_path(&format!("/portfolio/events/orders/{order_id}/decrease"));
+        self.send(Method::POST, &path, Some(&params), Some(&body), true)
+            .await
+    }
+
+    /// Submit a batch of orders via the V2 event-order endpoint.
+    ///
+    /// **Requires auth.**
+    pub async fn batch_create_orders_v2(
+        &self,
+        body: BatchCreateOrdersV2Request,
+    ) -> Result<BatchCreateOrdersV2Response, KalshiError> {
+        let path = Self::full_path("/portfolio/events/orders/batched");
+        self.send(Method::POST, &path, Option::<&()>::None, Some(&body), true)
+            .await
+    }
+
+    /// Cancel a batch of orders via the V2 event-order endpoint.
+    ///
+    /// **Requires auth.**
+    pub async fn batch_cancel_orders_v2(
+        &self,
+        body: BatchCancelOrdersV2Request,
+    ) -> Result<BatchCancelOrdersV2Response, KalshiError> {
+        let path = Self::full_path("/portfolio/events/orders/batched");
+        self.send(
+            Method::DELETE,
+            &path,
+            Option::<&()>::None,
+            Some(&body),
+            true,
+        )
+        .await
     }
 
     pub async fn get_fcm_orders(

--- a/src/rest/trades.rs
+++ b/src/rest/trades.rs
@@ -36,6 +36,10 @@ pub struct Trade {
     #[serde(default)]
     pub taker_book_side: Option<BookSide>,
     pub created_time: String,
+    /// True for block trades matched off-book (e.g. via RFQ). Added 2026-05-29.
+    /// Defaults to `false` for payloads predating this field.
+    #[serde(default)]
+    pub is_block_trade: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -54,6 +58,9 @@ pub struct GetTradesParams {
     pub limit: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
+    /// Filter by block trade status. Omit to return all trades.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_block_trade: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -136,6 +136,7 @@ pub struct ErrorResponse {
 #[serde(rename_all = "snake_case")]
 pub enum FeeType {
     Quadratic,
+    QuadraticWithMakerFees,
     Flat,
     #[serde(other)]
     Unknown,

--- a/src/ws/subscription.rs
+++ b/src/ws/subscription.rs
@@ -77,25 +77,32 @@ impl SubscriptionTracker {
                 }
                 let values = target.get_or_insert_with(Vec::new);
                 match action {
-                    WsUpdateAction::AddMarkets => {
+                    WsUpdateAction::AddMarkets | WsUpdateAction::SubscribeIndices => {
                         for value in incoming {
                             if !values.iter().any(|v| v == &value) {
                                 values.push(value);
                             }
                         }
                     }
-                    WsUpdateAction::DeleteMarkets => {
+                    WsUpdateAction::DeleteMarkets | WsUpdateAction::UnsubscribeIndices => {
                         values.retain(|current| !incoming.iter().any(|value| value == current));
                         if values.is_empty() {
                             *target = None;
                         }
                     }
-                    WsUpdateAction::GetSnapshot => {}
+                    WsUpdateAction::GetSnapshot | WsUpdateAction::Indexlist => {}
                 }
             };
 
-        apply_vec(&mut params.market_tickers, incoming_tickers, update.action);
-        apply_vec(&mut params.market_ids, incoming_ids, update.action);
+        if update.action.is_index_action() {
+            // CF Benchmarks index actions only mutate the tracked index set so
+            // that a reconnect resubscribes with the correct indices.
+            let incoming_indices = update.index_ids.clone().unwrap_or_default();
+            apply_vec(&mut params.index_ids, incoming_indices, update.action);
+        } else {
+            apply_vec(&mut params.market_tickers, incoming_tickers, update.action);
+            apply_vec(&mut params.market_ids, incoming_ids, update.action);
+        }
 
         if let Some(value) = update.send_initial_snapshot {
             params.send_initial_snapshot = Some(value);
@@ -176,6 +183,7 @@ mod tests {
             market_ids: None,
             send_initial_snapshot: Some(true),
             skip_ticker_ack: Some(true),
+            index_ids: None,
         };
         tracker.apply_update(&update);
 
@@ -218,10 +226,58 @@ mod tests {
             market_ids: None,
             send_initial_snapshot: None,
             skip_ticker_ack: None,
+            index_ids: None,
         };
         tracker.apply_update(&update);
 
         let updated = tracker.active.get(&10).unwrap();
         assert_eq!(updated.market_tickers, params.market_tickers);
+    }
+
+    #[test]
+    fn subscription_tracker_apply_update_tracks_cfbenchmarks_indices() {
+        let mut tracker = SubscriptionTracker::default();
+        let params = WsSubscriptionParamsV2 {
+            channels: vec![WsChannelV2::CfbenchmarksValue],
+            index_ids: Some(vec!["BRTI".to_string()]),
+            ..Default::default()
+        };
+        tracker.active.insert(7, params);
+
+        let add = WsUpdateSubscriptionParamsV2 {
+            action: WsUpdateAction::SubscribeIndices,
+            sid: Some(7),
+            sids: None,
+            market_ticker: None,
+            market_tickers: None,
+            market_id: None,
+            market_ids: None,
+            send_initial_snapshot: None,
+            skip_ticker_ack: None,
+            index_ids: Some(vec!["ETHUSD_RR".to_string()]),
+        };
+        tracker.apply_update(&add);
+        let updated = tracker.active.get(&7).unwrap();
+        let indices = updated.index_ids.as_ref().unwrap();
+        assert!(indices.contains(&"BRTI".to_string()));
+        assert!(indices.contains(&"ETHUSD_RR".to_string()));
+
+        let remove = WsUpdateSubscriptionParamsV2 {
+            action: WsUpdateAction::UnsubscribeIndices,
+            sid: Some(7),
+            sids: None,
+            market_ticker: None,
+            market_tickers: None,
+            market_id: None,
+            market_ids: None,
+            send_initial_snapshot: None,
+            skip_ticker_ack: None,
+            index_ids: Some(vec!["BRTI".to_string()]),
+        };
+        tracker.apply_update(&remove);
+        let updated = tracker.active.get(&7).unwrap();
+        let indices = updated.index_ids.as_ref().unwrap();
+        assert!(!indices.contains(&"BRTI".to_string()));
+        assert!(indices.contains(&"ETHUSD_RR".to_string()));
     }
 }

--- a/src/ws/types/channel.rs
+++ b/src/ws/types/channel.rs
@@ -15,6 +15,8 @@ pub enum WsChannelV2 {
     Communications,
     OrderGroupUpdates,
     UserOrders,
+    /// CF Benchmarks reference index value feed. Added 2026-06-08 (AsyncAPI 2.0.0).
+    CfbenchmarksValue,
 }
 
 impl WsChannelV2 {
@@ -31,6 +33,7 @@ impl WsChannelV2 {
             WsChannelV2::Communications => "communications",
             WsChannelV2::OrderGroupUpdates => "order_group_updates",
             WsChannelV2::UserOrders => "user_orders",
+            WsChannelV2::CfbenchmarksValue => "cfbenchmarks_value",
         }
     }
 

--- a/src/ws/types/envelope.rs
+++ b/src/ws/types/envelope.rs
@@ -244,6 +244,20 @@ impl WsEnvelope {
                 seq,
                 msg: parse_msg(&msg)?,
             })),
+            WsMsgType::CfbenchmarksValue => {
+                Ok(WsMessageV2::Data(WsDataMessageV2::CfbenchmarksValue {
+                    sid,
+                    seq,
+                    msg: parse_msg(&msg)?,
+                }))
+            }
+            WsMsgType::CfbenchmarksValueIndexlist => Ok(WsMessageV2::Data(
+                WsDataMessageV2::CfbenchmarksValueIndexlist {
+                    sid,
+                    seq,
+                    msg: parse_msg(&msg)?,
+                },
+            )),
             WsMsgType::Communications => Ok(WsMessageV2::Unknown {
                 msg_type: WsMsgType::Communications,
                 raw: msg,
@@ -440,6 +454,20 @@ impl<'a> WsEnvelopeRef<'a> {
                 seq,
                 msg: parse_borrowed_msg(msg)?,
             })),
+            WsMsgType::CfbenchmarksValue => {
+                Ok(WsMessageRef::Data(WsDataMessageRef::CfbenchmarksValue {
+                    sid,
+                    seq,
+                    msg: parse_borrowed_msg(msg)?,
+                }))
+            }
+            WsMsgType::CfbenchmarksValueIndexlist => Ok(WsMessageRef::Data(
+                WsDataMessageRef::CfbenchmarksValueIndexlist {
+                    sid,
+                    seq,
+                    msg: parse_borrowed_msg(msg)?,
+                },
+            )),
             WsMsgType::Communications => Ok(WsMessageRef::Unknown {
                 msg_type: WsMsgType::Communications,
                 raw: msg,
@@ -552,6 +580,16 @@ pub enum WsDataMessageV2 {
         seq: Option<u64>,
         msg: WsUserOrder,
     },
+    CfbenchmarksValue {
+        sid: Option<u64>,
+        seq: Option<u64>,
+        msg: WsCfBenchmarksValue,
+    },
+    CfbenchmarksValueIndexlist {
+        sid: Option<u64>,
+        seq: Option<u64>,
+        msg: WsCfBenchmarksIndexList,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -625,6 +663,16 @@ pub enum WsDataMessageRef<'a> {
         sid: Option<u64>,
         seq: Option<u64>,
         msg: WsUserOrder,
+    },
+    CfbenchmarksValue {
+        sid: Option<u64>,
+        seq: Option<u64>,
+        msg: WsCfBenchmarksValueRef<'a>,
+    },
+    CfbenchmarksValueIndexlist {
+        sid: Option<u64>,
+        seq: Option<u64>,
+        msg: WsCfBenchmarksIndexListRef<'a>,
     },
 }
 
@@ -706,6 +754,20 @@ impl<'a> WsDataMessageRef<'a> {
             }
             WsDataMessageRef::UserOrder { sid, seq, msg } => {
                 WsDataMessageV2::UserOrder { sid, seq, msg }
+            }
+            WsDataMessageRef::CfbenchmarksValue { sid, seq, msg } => {
+                WsDataMessageV2::CfbenchmarksValue {
+                    sid,
+                    seq,
+                    msg: msg.into_owned(),
+                }
+            }
+            WsDataMessageRef::CfbenchmarksValueIndexlist { sid, seq, msg } => {
+                WsDataMessageV2::CfbenchmarksValueIndexlist {
+                    sid,
+                    seq,
+                    msg: msg.into_owned(),
+                }
             }
         }
     }

--- a/src/ws/types/messages/cfbenchmarks.rs
+++ b/src/ws/types/messages/cfbenchmarks.rs
@@ -1,0 +1,77 @@
+use serde::Deserialize;
+use std::borrow::Cow;
+
+/// Windowed-average metadata bundled with each CF Benchmarks value tick.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WsCfBenchmarksAvgData {
+    /// Average value over the window, formatted to 8 decimal places.
+    pub value: String,
+    /// Number of ticks counted in the window.
+    pub window_size: i64,
+    /// Window start boundary (unix ms).
+    pub window_start_ts_ms: i64,
+    /// Window end boundary, exclusive (unix ms).
+    pub window_end_ts_exclusive: i64,
+}
+
+/// Message payload for the `cfbenchmarks_value` WebSocket channel.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WsCfBenchmarksValue {
+    /// CF Benchmarks index ID (e.g. `"BRTI"`).
+    pub index_id: String,
+    /// When Kalshi received the upstream frame (unix ms).
+    pub received_at: i64,
+    /// The raw CF Benchmarks JSON frame, as a string.
+    pub data: String,
+    /// Trailing 60-second average metadata.
+    pub avg_60s_data: WsCfBenchmarksAvgData,
+    /// Present only during the final minute before quarter-hour close.
+    #[serde(default)]
+    pub last_60s_windowed_average_15min: Option<WsCfBenchmarksAvgData>,
+}
+
+/// Borrowed version of [`WsCfBenchmarksValue`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct WsCfBenchmarksValueRef<'a> {
+    #[serde(borrow)]
+    pub index_id: Cow<'a, str>,
+    pub received_at: i64,
+    #[serde(borrow)]
+    pub data: Cow<'a, str>,
+    pub avg_60s_data: WsCfBenchmarksAvgData,
+    #[serde(default)]
+    pub last_60s_windowed_average_15min: Option<WsCfBenchmarksAvgData>,
+}
+
+impl<'a> WsCfBenchmarksValueRef<'a> {
+    pub fn into_owned(self) -> WsCfBenchmarksValue {
+        WsCfBenchmarksValue {
+            index_id: self.index_id.into_owned(),
+            received_at: self.received_at,
+            data: self.data.into_owned(),
+            avg_60s_data: self.avg_60s_data,
+            last_60s_windowed_average_15min: self.last_60s_windowed_average_15min,
+        }
+    }
+}
+
+/// Response to the `indexlist` action on a `cfbenchmarks_value` subscription.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WsCfBenchmarksIndexList {
+    pub index_ids: Vec<String>,
+}
+
+/// Borrowed version of [`WsCfBenchmarksIndexList`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct WsCfBenchmarksIndexListRef<'a> {
+    #[serde(borrow)]
+    pub index_ids: Vec<Cow<'a, str>>,
+}
+
+impl<'a> WsCfBenchmarksIndexListRef<'a> {
+    pub fn into_owned(self) -> WsCfBenchmarksIndexList {
+        WsCfBenchmarksIndexList {
+            index_ids: self.index_ids.into_iter().map(Cow::into_owned).collect(),
+        }
+    }
+}

--- a/src/ws/types/messages/mod.rs
+++ b/src/ws/types/messages/mod.rs
@@ -35,3 +35,6 @@ pub use user_orders::*;
 
 mod communications;
 pub use communications::*;
+
+mod cfbenchmarks;
+pub use cfbenchmarks::*;

--- a/src/ws/types/msg_type.rs
+++ b/src/ws/types/msg_type.rs
@@ -29,6 +29,8 @@ pub enum WsMsgType {
     QuoteExecuted,
     OrderGroupUpdates,
     UserOrder,
+    CfbenchmarksValue,
+    CfbenchmarksValueIndexlist,
     Unknown(String),
 }
 
@@ -60,6 +62,8 @@ impl WsMsgType {
             WsMsgType::QuoteExecuted => "quote_executed",
             WsMsgType::OrderGroupUpdates => "order_group_updates",
             WsMsgType::UserOrder => "user_order",
+            WsMsgType::CfbenchmarksValue => "cfbenchmarks_value",
+            WsMsgType::CfbenchmarksValueIndexlist => "cfbenchmarks_value_indexlist",
             WsMsgType::Unknown(value) => value.as_str(),
         }
     }
@@ -91,6 +95,8 @@ impl WsMsgType {
             "quote_executed" => WsMsgType::QuoteExecuted,
             "order_group_updates" => WsMsgType::OrderGroupUpdates,
             "user_order" => WsMsgType::UserOrder,
+            "cfbenchmarks_value" => WsMsgType::CfbenchmarksValue,
+            "cfbenchmarks_value_indexlist" => WsMsgType::CfbenchmarksValueIndexlist,
             _ => return None,
         })
     }
@@ -122,6 +128,8 @@ impl WsMsgType {
             "quote_executed" => WsMsgType::QuoteExecuted,
             "order_group_updates" => WsMsgType::OrderGroupUpdates,
             "user_order" => WsMsgType::UserOrder,
+            "cfbenchmarks_value" => WsMsgType::CfbenchmarksValue,
+            "cfbenchmarks_value_indexlist" => WsMsgType::CfbenchmarksValueIndexlist,
             _ => WsMsgType::Unknown(value),
         }
     }

--- a/src/ws/types/subscription.rs
+++ b/src/ws/types/subscription.rs
@@ -25,6 +25,10 @@ pub struct WsSubscriptionParamsV2 {
     pub shard_factor: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_key: Option<u32>,
+    /// CF Benchmarks index IDs for `cfbenchmarks_value` subscriptions.
+    /// Use `["all"]` to receive every available index.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_ids: Option<Vec<String>>,
 }
 
 impl WsSubscriptionParamsV2 {

--- a/src/ws/types/subscription.rs
+++ b/src/ws/types/subscription.rs
@@ -150,6 +150,11 @@ pub struct WsUpdateSubscriptionParamsV2 {
     pub send_initial_snapshot: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub skip_ticker_ack: Option<bool>,
+    /// CF Benchmarks index IDs to add or remove. Required for the
+    /// `subscribe_indices` / `unsubscribe_indices` actions; use `["all"]` to
+    /// track every available index.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_ids: Option<Vec<String>>,
 }
 
 impl WsUpdateSubscriptionParamsV2 {
@@ -168,6 +173,26 @@ pub enum WsUpdateAction {
     AddMarkets,
     DeleteMarkets,
     GetSnapshot,
+    /// Add the supplied `index_ids` to a `cfbenchmarks_value` subscription.
+    SubscribeIndices,
+    /// Remove the supplied `index_ids` from a `cfbenchmarks_value` subscription.
+    UnsubscribeIndices,
+    /// Request the available CF Benchmarks index IDs without modifying the
+    /// subscription (server replies with a `cfbenchmarks_value_indexlist`).
+    Indexlist,
+}
+
+impl WsUpdateAction {
+    /// Whether this action operates on CF Benchmarks index IDs rather than
+    /// market targets.
+    pub fn is_index_action(self) -> bool {
+        matches!(
+            self,
+            WsUpdateAction::SubscribeIndices
+                | WsUpdateAction::UnsubscribeIndices
+                | WsUpdateAction::Indexlist
+        )
+    }
 }
 
 pub(crate) fn validate_update(params: &WsUpdateSubscriptionParamsV2) -> Result<(), KalshiError> {
@@ -200,6 +225,38 @@ pub(crate) fn validate_update(params: &WsUpdateSubscriptionParamsV2) -> Result<(
         .unwrap_or(false);
     let has_any_market_tickers = has_market_ticker || has_market_tickers;
     let has_any_market_ids = has_market_id || has_market_ids;
+    let has_index_ids = params
+        .index_ids
+        .as_ref()
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+
+    // CF Benchmarks index actions are mutually exclusive with market targets and
+    // have their own `index_ids` requirements.
+    if params.action.is_index_action() {
+        if has_any_market_tickers || has_any_market_ids {
+            return Err(KalshiError::InvalidParams(
+                "update_subscription: index actions do not support market_ticker(s) or market_id(s)"
+                    .to_string(),
+            ));
+        }
+        if matches!(
+            params.action,
+            WsUpdateAction::SubscribeIndices | WsUpdateAction::UnsubscribeIndices
+        ) && !has_index_ids
+        {
+            return Err(KalshiError::InvalidParams(
+                "update_subscription: subscribe_indices/unsubscribe_indices require index_ids"
+                    .to_string(),
+            ));
+        }
+    } else if params.index_ids.is_some() {
+        return Err(KalshiError::InvalidParams(
+            "update_subscription: index_ids is only valid for subscribe_indices, \
+             unsubscribe_indices, or indexlist actions"
+                .to_string(),
+        ));
+    }
 
     if has_market_ticker && has_market_tickers {
         return Err(KalshiError::InvalidParams(
@@ -418,6 +475,7 @@ mod tests {
             market_ids: None,
             send_initial_snapshot: None,
             skip_ticker_ack: None,
+            index_ids: None,
         };
         assert!(validate_update(&both).is_err());
 
@@ -431,6 +489,7 @@ mod tests {
             market_ids: None,
             send_initial_snapshot: None,
             skip_ticker_ack: None,
+            index_ids: None,
         };
         assert!(validate_update(&multi).is_err());
 
@@ -444,6 +503,7 @@ mod tests {
             market_ids: None,
             send_initial_snapshot: None,
             skip_ticker_ack: None,
+            index_ids: None,
         };
         assert!(validate_update(&valid).is_ok());
     }
@@ -460,6 +520,7 @@ mod tests {
             market_ids: None,
             send_initial_snapshot: None,
             skip_ticker_ack: None,
+            index_ids: None,
         };
         assert!(validate_update(&params).is_err());
     }
@@ -476,6 +537,7 @@ mod tests {
             market_ids: None,
             send_initial_snapshot: None,
             skip_ticker_ack: None,
+            index_ids: None,
         };
         assert!(validate_update(&params).is_err());
     }
@@ -492,8 +554,91 @@ mod tests {
             market_ids: None,
             send_initial_snapshot: None,
             skip_ticker_ack: None,
+            index_ids: None,
         };
         assert!(validate_update(&params).is_ok());
+    }
+
+    #[test]
+    fn validate_update_subscribe_indices_requires_index_ids() {
+        let missing = WsUpdateSubscriptionParamsV2 {
+            action: WsUpdateAction::SubscribeIndices,
+            sid: Some(1),
+            sids: None,
+            market_ticker: None,
+            market_tickers: None,
+            market_id: None,
+            market_ids: None,
+            send_initial_snapshot: None,
+            skip_ticker_ack: None,
+            index_ids: None,
+        };
+        assert!(validate_update(&missing).is_err());
+
+        let ok = WsUpdateSubscriptionParamsV2 {
+            action: WsUpdateAction::SubscribeIndices,
+            sid: Some(1),
+            sids: None,
+            market_ticker: None,
+            market_tickers: None,
+            market_id: None,
+            market_ids: None,
+            send_initial_snapshot: None,
+            skip_ticker_ack: None,
+            index_ids: Some(vec!["BRTI".to_string()]),
+        };
+        assert!(validate_update(&ok).is_ok());
+    }
+
+    #[test]
+    fn validate_update_indexlist_allows_empty_index_ids() {
+        let params = WsUpdateSubscriptionParamsV2 {
+            action: WsUpdateAction::Indexlist,
+            sid: Some(1),
+            sids: None,
+            market_ticker: None,
+            market_tickers: None,
+            market_id: None,
+            market_ids: None,
+            send_initial_snapshot: None,
+            skip_ticker_ack: None,
+            index_ids: None,
+        };
+        assert!(validate_update(&params).is_ok());
+    }
+
+    #[test]
+    fn validate_update_index_actions_reject_market_targets() {
+        let params = WsUpdateSubscriptionParamsV2 {
+            action: WsUpdateAction::SubscribeIndices,
+            sid: Some(1),
+            sids: None,
+            market_ticker: Some("TICKER".to_string()),
+            market_tickers: None,
+            market_id: None,
+            market_ids: None,
+            send_initial_snapshot: None,
+            skip_ticker_ack: None,
+            index_ids: Some(vec!["BRTI".to_string()]),
+        };
+        assert!(validate_update(&params).is_err());
+    }
+
+    #[test]
+    fn validate_update_index_ids_rejected_for_market_actions() {
+        let params = WsUpdateSubscriptionParamsV2 {
+            action: WsUpdateAction::AddMarkets,
+            sid: Some(1),
+            sids: None,
+            market_ticker: Some("TICKER".to_string()),
+            market_tickers: None,
+            market_id: None,
+            market_ids: None,
+            send_initial_snapshot: None,
+            skip_ticker_ack: None,
+            index_ids: Some(vec!["BRTI".to_string()]),
+        };
+        assert!(validate_update(&params).is_err());
     }
 
     #[test]

--- a/src/ws/types/wire.rs
+++ b/src/ws/types/wire.rs
@@ -155,6 +155,18 @@ pub(super) enum WsWireMessage {
         seq: Option<u64>,
         msg: WsUserOrder,
     },
+    #[serde(rename = "cfbenchmarks_value")]
+    CfbenchmarksValue {
+        sid: Option<u64>,
+        seq: Option<u64>,
+        msg: WsCfBenchmarksValue,
+    },
+    #[serde(rename = "cfbenchmarks_value_indexlist")]
+    CfbenchmarksValueIndexlist {
+        sid: Option<u64>,
+        seq: Option<u64>,
+        msg: WsCfBenchmarksIndexList,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -275,6 +287,12 @@ impl WsWireMessage {
             }
             WsWireMessage::UserOrder { sid, seq, msg } => {
                 WsMessageV2::Data(WsDataMessageV2::UserOrder { sid, seq, msg })
+            }
+            WsWireMessage::CfbenchmarksValue { sid, seq, msg } => {
+                WsMessageV2::Data(WsDataMessageV2::CfbenchmarksValue { sid, seq, msg })
+            }
+            WsWireMessage::CfbenchmarksValueIndexlist { sid, seq, msg } => {
+                WsMessageV2::Data(WsDataMessageV2::CfbenchmarksValueIndexlist { sid, seq, msg })
             }
         }
     }
@@ -444,6 +462,20 @@ pub(super) enum WsWireMessageRef<'a> {
         seq: Option<u64>,
         msg: WsUserOrder,
     },
+    #[serde(rename = "cfbenchmarks_value")]
+    CfbenchmarksValue {
+        sid: Option<u64>,
+        seq: Option<u64>,
+        #[serde(borrow)]
+        msg: WsCfBenchmarksValueRef<'a>,
+    },
+    #[serde(rename = "cfbenchmarks_value_indexlist")]
+    CfbenchmarksValueIndexlist {
+        sid: Option<u64>,
+        seq: Option<u64>,
+        #[serde(borrow)]
+        msg: WsCfBenchmarksIndexListRef<'a>,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -565,6 +597,12 @@ impl<'a> WsWireMessageRef<'a> {
             }
             WsWireMessageRef::UserOrder { sid, seq, msg } => {
                 WsMessageRef::Data(WsDataMessageRef::UserOrder { sid, seq, msg })
+            }
+            WsWireMessageRef::CfbenchmarksValue { sid, seq, msg } => {
+                WsMessageRef::Data(WsDataMessageRef::CfbenchmarksValue { sid, seq, msg })
+            }
+            WsWireMessageRef::CfbenchmarksValueIndexlist { sid, seq, msg } => {
+                WsMessageRef::Data(WsDataMessageRef::CfbenchmarksValueIndexlist { sid, seq, msg })
             }
         }
     }

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -4,13 +4,13 @@ pub(crate) use cargo_husky as _;
 use kalshi_fast::{
     ApplySubaccountTransferResponse, BookSide, BuySell, CreateOrderRequest,
     CreateSubaccountResponse, ErrorResponse, EventData, EventMetadata, EventStatus,
-    GetAccountApiLimitsResponse, GetEventsParams, GetExchangeAnnouncementsResponse,
-    GetExchangeScheduleResponse, GetExchangeStatusResponse, GetFillsParams, GetFillsResponse,
-    GetMarketOrderbookResponse, GetMarketsParams, GetOrderQueuePositionsParams, GetOrdersParams,
-    GetPositionsParams, GetSeriesFeeChangesParams, GetSeriesFeeChangesResponse,
-    GetSettlementsParams, GetSettlementsResponse, GetSubaccountBalancesResponse,
-    GetSubaccountTransfersParams, GetSubaccountTransfersResponse, GetTradesParams,
-    GetTradesResponse, GetUserDataTimestampResponse, MarketMetadata, MarketStatus,
+    GetAccountApiLimitsResponse, GetAccountEndpointCostsResponse, GetEventsParams,
+    GetExchangeAnnouncementsResponse, GetExchangeScheduleResponse, GetExchangeStatusResponse,
+    GetFillsParams, GetFillsResponse, GetMarketOrderbookResponse, GetMarketsParams,
+    GetOrderQueuePositionsParams, GetOrdersParams, GetPositionsParams, GetSeriesFeeChangesParams,
+    GetSeriesFeeChangesResponse, GetSettlementsParams, GetSettlementsResponse,
+    GetSubaccountBalancesResponse, GetSubaccountTransfersParams, GetSubaccountTransfersResponse,
+    GetTradesParams, GetTradesResponse, GetUserDataTimestampResponse, MarketMetadata, MarketStatus,
     MarketStatusConversionError, MarketStatusQuery, MveFilter, OrderStatus, OrderType,
     PositionCountFilter, PriceRange, SelfTradePreventionType, TimeInForce, TradeTakerSide, YesNo,
 };
@@ -1195,6 +1195,41 @@ fn get_account_api_limits_response_deserializes() {
     assert_eq!(resp.grants[0].source, "volume");
     assert!(resp.grants[0].expires_ts.is_none());
     assert_eq!(resp.grants[1].expires_ts, Some(9999999999));
+}
+
+#[test]
+fn get_account_api_limits_response_tolerates_missing_grants() {
+    // Defensive: a payload without `grants` should still parse (empty vec).
+    let json = r#"{
+        "usage_tier": "basic",
+        "read":  {"refill_rate": 20, "bucket_capacity": 200},
+        "write": {"refill_rate": 10, "bucket_capacity": 20}
+    }"#;
+    let resp: GetAccountApiLimitsResponse = serde_json::from_str(json).unwrap();
+    assert!(resp.grants.is_empty());
+}
+
+#[test]
+fn get_account_endpoint_costs_response_deserializes() {
+    let json = r#"{
+        "default_cost": 10,
+        "endpoint_costs": [
+            {"method":"POST","path":"/portfolio/orders","cost":100},
+            {"method":"DELETE","path":"/portfolio/orders/batched","cost":50}
+        ]
+    }"#;
+
+    let resp: GetAccountEndpointCostsResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(resp.default_cost, 10);
+    assert_eq!(resp.endpoint_costs.len(), 2);
+    assert_eq!(resp.endpoint_costs[0].method, "POST");
+    assert_eq!(resp.endpoint_costs[0].path, "/portfolio/orders");
+    assert_eq!(resp.endpoint_costs[0].cost, 100);
+
+    // Tolerates missing/null endpoint_costs.
+    let resp: GetAccountEndpointCostsResponse =
+        serde_json::from_str(r#"{"default_cost": 10}"#).unwrap();
+    assert!(resp.endpoint_costs.is_empty());
 }
 
 #[test]

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -1175,12 +1175,26 @@ fn get_settlements_response_deserializes() {
 
 #[test]
 fn get_account_api_limits_response_deserializes() {
-    let json = r#"{"usage_tier":"basic","read_limit":20,"write_limit":10}"#;
+    let json = r#"{
+        "usage_tier": "basic",
+        "read":  {"refill_rate": 20, "bucket_capacity": 200},
+        "write": {"refill_rate": 10, "bucket_capacity": 20},
+        "grants": [
+            {"exchange_instance":"event_contract","level":"premier","source":"volume"},
+            {"exchange_instance":"margined","level":"paragon","expires_ts":9999999999,"source":"manual"}
+        ]
+    }"#;
 
     let resp: GetAccountApiLimitsResponse = serde_json::from_str(json).unwrap();
     assert_eq!(resp.usage_tier, "basic");
-    assert_eq!(resp.read_limit, 20);
-    assert_eq!(resp.write_limit, 10);
+    assert_eq!(resp.read.refill_rate, 20);
+    assert_eq!(resp.read.bucket_capacity, 200);
+    assert_eq!(resp.write.refill_rate, 10);
+    assert_eq!(resp.grants.len(), 2);
+    assert_eq!(resp.grants[0].level, "premier");
+    assert_eq!(resp.grants[0].source, "volume");
+    assert!(resp.grants[0].expires_ts.is_none());
+    assert_eq!(resp.grants[1].expires_ts, Some(9999999999));
 }
 
 #[test]

--- a/tests/ws_get_snapshot.rs
+++ b/tests/ws_get_snapshot.rs
@@ -60,6 +60,7 @@ async fn ws_demo_orderbook_get_snapshot_returns_snapshot_without_mutating_subscr
             market_ids: None,
             send_initial_snapshot: None,
             skip_ticker_ack: None,
+            index_ids: None,
         })
         .await
         .expect("get_snapshot update failed");


### PR DESCRIPTION
## Summary

This release (0.6.0) adds support for three major API updates: the new lower-cost V2 event-order endpoints (`/portfolio/events/orders/*`), the CF Benchmarks reference index value feed via WebSocket, and a restructured API rate-limit response format reflecting automated tier management.

## Key Changes

### REST API

- **V2 Event-Order Endpoints**: Added six new `KalshiRestClient` methods for the `/portfolio/events/orders/*` endpoints:
  - `create_order_v2()` – Place orders with single price + `BookSide` (lower rate-limit cost)
  - `cancel_order_v2()` – Cancel by order ID
  - `amend_order_v2()` – Modify price and quantity
  - `decrease_order_v2()` – Reduce position by amount or to target
  - `batch_create_orders_v2()` – Batch order placement
  - `batch_cancel_orders_v2()` – Batch cancellation
  
  New request/response types: `CreateOrderV2Request`, `CreateOrderV2Response`, `CancelOrderV2Params`, `CancelOrderV2Response`, `AmendOrderV2Request`, `AmendOrderV2Response`, `DecreaseOrderV2Request`, `DecreaseOrderV2Response`, `BatchCreateOrdersV2Request`, `BatchCreateOrdersV2Response`, and related batch order types.

- **API Rate-Limit Restructuring** (`GetAccountApiLimitsResponse`): Replaced flat `read_limit`/`write_limit` fields with nested `BucketLimit` objects (`read`, `write`) and added `grants: Vec<ApiUsageLevelGrant>` for active usage-level grants. **Breaking change** for callers accessing the old fields.

- **Block Trade Indicators**: Added `is_block_trade: bool` field to `Trade` struct (defaults to `false` for backward compatibility) and `is_block_trade: Option<bool>` filter to `GetTradesParams`.

- **Fee Type Enum**: Added `FeeType::QuadraticWithMakerFees` variant and `#[serde(other)] Unknown` catch-all to prevent panics on future variants.

### WebSocket API

- **CF Benchmarks Channel**: Full support for the new `cfbenchmarks_value` AsyncAPI channel:
  - `WsChannelV2::CfbenchmarksValue` variant
  - `index_ids: Option<Vec<String>>` subscription parameter (use `["all"]` for all indices)
  - Two message types: `cfbenchmarks_value` (per-index value + 60-second windowed average) and `cfbenchmarks_value_indexlist` (available indices)
  - New types: `WsCfBenchmarksValue`, `WsCfBenchmarksValueRef`, `WsCfBenchmarksAvgData`, `WsCfBenchmarksIndexList`, `WsCfBenchmarksIndexListRef` in `ws::types::messages::cfbenchmarks`
  - Integrated into wire and envelope parsing paths for both owned and borrowed message flows

### Documentation & Testing

- Updated `CHANGELOG.md` with full 0.6.0 release notes and disposition of all API changes
- Updated `docs/spec-parity.md` with detailed notes on new features and breaking changes
- Updated `GOTCHAS.md` with corrected external API hostnames (introduced 2026-05-07)
- Added comprehensive parsing test for the new `GetAccountApiLimitsResponse` structure

## Implementation Details

- V2 order types use `FixedPointCount` and `FixedPointDollars` for precision (consistent with existing patterns)
- Batch responses include per-order error fields for partial-failure handling
- CF Benchmarks windowed-average metadata includes window boundaries and tick counts for analytics
- All new WebSocket message types support both zero-copy borrowed (`Ref`) and owned variants for flexibility
- Rate-limit bucket configuration uses `refill_rate` (tokens/sec) and `bucket_capacity` (max tokens)

https://claude.ai/code/session_013FmTqRrJicnCgijjLUUtKY