### PR TITLE
v0.6.1: WS reader liveness — exit on dropped receiver, client pings with pong deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ Kalshi docs snapshot tracked by that release.
 For crate versioning policy and bump rules, see [`VERSIONING.md`](VERSIONING.md).
 
 
+## [0.6.1] - 2026-06-10
+
+### Compatibility
+
+- Docs snapshot: 2026-06-08
+- OpenAPI: 3.20.0
+- AsyncAPI: 2.0.0
+- Validated through changelog: 2026-06-08
+
+### Added
+
+- [Rust API] Added `ping_interval: Option<Duration>` and `pong_timeout: Duration` to
+  `WsReconnectConfig` for transport keepalive (#47). When `ping_interval` is set, the managed
+  reader sends a `Ping` frame on that cadence and treats the connection as dead — routing into the
+  existing reconnect path — if no inbound frame arrives within `pong_timeout` of a ping. Defaults
+  (`None` / 10 s) preserve the previous behavior; downstream struct-literal construction of
+  `WsReconnectConfig` should add `..Default::default()`.
+
+### Fixed
+
+- [Rust API] The reader loop now exits when the event receiver is dropped instead of misreading
+  the failed send as a transport error and reconnecting forever with no consumer.
+
+
 ## [0.6.0] - 2026-06-08
 
 ### Compatibility

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "kalshi-fast-rs"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kalshi-fast-rs"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "High-performance async Rust client for Kalshi prediction markets API with full WebSocket support"
 license = "MIT"

--- a/src/ws/client.rs
+++ b/src/ws/client.rs
@@ -486,6 +486,7 @@ mod tests {
             max_delay: Duration::from_secs(5),
             jitter: 0.0,
             resubscribe: false,
+            ..Default::default()
         };
         let mut client = KalshiWsClient::connect_authenticated(env, auth, config)
             .await

--- a/src/ws/low_level.rs
+++ b/src/ws/low_level.rs
@@ -103,6 +103,13 @@ impl KalshiWsLowLevelClient {
         Ok(())
     }
 
+    /// Read the next raw frame.
+    ///
+    /// Blocks until a frame arrives — there is no read deadline at this
+    /// layer. Wrap in [`tokio::time::timeout`] if you need one, or use
+    /// [`KalshiWsClient`] with
+    /// [`WsReconnectConfig::ping_interval`](crate::WsReconnectConfig::ping_interval)
+    /// for transport keepalive.
     pub async fn next_frame(&mut self) -> Result<Message, KalshiError> {
         match self.read.next().await {
             Some(Ok(msg)) => Ok(msg),

--- a/src/ws/reader.rs
+++ b/src/ws/reader.rs
@@ -11,7 +11,7 @@ use bytes::Bytes;
 use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc, watch};
-use tokio::time::sleep;
+use tokio::time::{Duration, Instant, MissedTickBehavior, interval_at, sleep, sleep_until};
 use tokio_tungstenite::tungstenite::Message;
 
 #[derive(Debug, Deserialize)]
@@ -51,6 +51,15 @@ pub(crate) async fn reader_loop(
 ) {
     let mut outgoing_closed = false;
 
+    // Keepalive: ping every `ping_interval`; any inbound frame proves the read
+    // path and clears the pong deadline. Both arms are gated off when disabled,
+    // so the placeholder period never fires.
+    let ping_enabled = config.ping_interval.is_some();
+    let ping_interval = config.ping_interval.unwrap_or(Duration::from_secs(3600));
+    let mut keepalive = interval_at(Instant::now() + ping_interval, ping_interval);
+    keepalive.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut pong_deadline: Option<Instant> = None;
+
     loop {
         if *shutdown_rx.borrow() || event_tx.is_closed() {
             return;
@@ -63,9 +72,21 @@ pub(crate) async fn reader_loop(
             }
             frame = client.next_frame() => {
                 match frame {
-                    Ok(msg) => handle_incoming_message(msg, &mut client, &tracker, &event_tx, mode).await,
+                    Ok(msg) => {
+                        pong_deadline = None;
+                        handle_incoming_message(msg, &mut client, &tracker, &event_tx, mode).await
+                    }
                     Err(err) => Err(err),
                 }
+            }
+            _ = keepalive.tick(), if ping_enabled => {
+                if pong_deadline.is_none() {
+                    pong_deadline = Some(Instant::now() + config.pong_timeout);
+                }
+                client.send_raw(Message::Ping(Vec::new())).await
+            }
+            _ = sleep_until(pong_deadline.unwrap_or_else(Instant::now)), if pong_deadline.is_some() => {
+                Err(KalshiError::Ws("websocket keepalive timed out".to_string()))
             }
             maybe_out = outgoing_rx.recv(), if !outgoing_closed => {
                 match maybe_out {
@@ -98,6 +119,8 @@ pub(crate) async fn reader_loop(
                     if event_tx.is_closed() {
                         return;
                     }
+                    keepalive.reset();
+                    pong_deadline = None;
                 }
                 Err(err) => {
                     if *shutdown_rx.borrow() {
@@ -283,7 +306,7 @@ mod tests {
     use crate::auth::tests::load_test_auth;
     use crate::ws::event::{WsReaderConfig, WsReaderMode};
     use crate::ws::{KalshiWsClient, WsReconnectConfig};
-    use futures::SinkExt;
+    use futures::{SinkExt, StreamExt};
     use serde_json::json;
     use tokio::net::TcpListener;
     use tokio::time::{Duration, timeout};
@@ -398,6 +421,7 @@ mod tests {
             max_delay: Duration::from_millis(1),
             jitter: 0.0,
             resubscribe: false,
+            ..Default::default()
         };
         let client = KalshiWsLowLevelClient::connect_authenticated(env.clone(), auth.clone())
             .await
@@ -464,6 +488,7 @@ mod tests {
             max_delay: Duration::from_millis(50),
             jitter: 0.0,
             resubscribe: false,
+            ..Default::default()
         };
         let mut client = KalshiWsClient::connect_authenticated(env, auth, config)
             .await
@@ -494,6 +519,146 @@ mod tests {
             .expect("timeout 2")
             .expect("event 2");
         assert!(matches!(second, WsEvent::Message(_)));
+
+        server.await.expect("server");
+    }
+
+    #[tokio::test]
+    async fn reader_keepalive_sends_pings() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let mut ws = accept_async(stream).await.expect("accept ws");
+            loop {
+                let frame = timeout(Duration::from_secs(2), ws.next())
+                    .await
+                    .expect("ping within window")
+                    .expect("frame")
+                    .expect("ok frame");
+                if matches!(frame, Message::Ping(_)) {
+                    return;
+                }
+            }
+        });
+
+        let auth = load_test_auth();
+        let env = KalshiEnvironment {
+            rest_origin: Url::parse("http://127.0.0.1/").expect("url"),
+            ws_url: format!("ws://{}", addr),
+        };
+        let config = WsReconnectConfig {
+            ping_interval: Some(Duration::from_millis(25)),
+            pong_timeout: Duration::from_secs(1),
+            ..Default::default()
+        };
+        let mut client = KalshiWsClient::connect_authenticated(env, auth, config)
+            .await
+            .expect("connect");
+        let _receiver = client
+            .start_reader_v2(WsReaderConfig {
+                buffer_size: 4,
+                mode: WsReaderMode::Owned,
+            })
+            .await
+            .expect("start reader");
+
+        server.await.expect("server");
+    }
+
+    #[tokio::test]
+    async fn reader_keepalive_timeout_triggers_reconnect() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept 1");
+            // Handshake, then never poll: pings are swallowed, no pong or
+            // data ever goes out, but the TCP connection stays open.
+            let ws = accept_async(stream).await.expect("accept ws 1");
+
+            let (stream, _) = timeout(Duration::from_secs(2), listener.accept())
+                .await
+                .expect("reconnect within window")
+                .expect("accept 2");
+            let _ws2 = accept_async(stream).await.expect("accept ws 2");
+            drop(ws);
+        });
+
+        let auth = load_test_auth();
+        let env = KalshiEnvironment {
+            rest_origin: Url::parse("http://127.0.0.1/").expect("url"),
+            ws_url: format!("ws://{}", addr),
+        };
+        let config = WsReconnectConfig {
+            max_retries: Some(3),
+            base_delay: Duration::from_millis(10),
+            max_delay: Duration::from_millis(10),
+            jitter: 0.0,
+            resubscribe: false,
+            ping_interval: Some(Duration::from_millis(25)),
+            pong_timeout: Duration::from_millis(50),
+        };
+        let mut client = KalshiWsClient::connect_authenticated(env, auth, config)
+            .await
+            .expect("connect");
+        let receiver = client
+            .start_reader_v2(WsReaderConfig {
+                buffer_size: 4,
+                mode: WsReaderMode::Owned,
+            })
+            .await
+            .expect("start reader");
+
+        let reconnect = timeout(Duration::from_secs(2), receiver.next())
+            .await
+            .expect("timeout reconnect")
+            .expect("event reconnect");
+        assert!(matches!(reconnect, WsEvent::Reconnected { .. }));
+
+        server.await.expect("server");
+    }
+
+    #[tokio::test]
+    async fn reader_default_config_sends_no_pings() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let mut ws = accept_async(stream).await.expect("accept ws");
+            loop {
+                match timeout(Duration::from_millis(300), ws.next()).await {
+                    Ok(frame) => {
+                        let frame = frame.expect("frame").expect("ok frame");
+                        assert!(
+                            !matches!(frame, Message::Ping(_)),
+                            "ping sent with keepalive disabled"
+                        );
+                    }
+                    // Quiet window elapsed without a ping.
+                    Err(_) => return,
+                }
+            }
+        });
+
+        let auth = load_test_auth();
+        let env = KalshiEnvironment {
+            rest_origin: Url::parse("http://127.0.0.1/").expect("url"),
+            ws_url: format!("ws://{}", addr),
+        };
+        let mut client =
+            KalshiWsClient::connect_authenticated(env, auth, WsReconnectConfig::default())
+                .await
+                .expect("connect");
+        let _receiver = client
+            .start_reader_v2(WsReaderConfig {
+                buffer_size: 4,
+                mode: WsReaderMode::Owned,
+            })
+            .await
+            .expect("start reader");
 
         server.await.expect("server");
     }

--- a/src/ws/reader.rs
+++ b/src/ws/reader.rs
@@ -52,7 +52,7 @@ pub(crate) async fn reader_loop(
     let mut outgoing_closed = false;
 
     loop {
-        if *shutdown_rx.borrow() {
+        if *shutdown_rx.borrow() || event_tx.is_closed() {
             return;
         }
 
@@ -79,6 +79,10 @@ pub(crate) async fn reader_loop(
         };
 
         if let Err(_err) = result {
+            if event_tx.is_closed() {
+                return;
+            }
+
             match handle_reconnect(
                 &mut client,
                 &env,
@@ -90,7 +94,11 @@ pub(crate) async fn reader_loop(
             )
             .await
             {
-                Ok(()) => {}
+                Ok(()) => {
+                    if event_tx.is_closed() {
+                        return;
+                    }
+                }
                 Err(err) => {
                     if *shutdown_rx.borrow() {
                         return;
@@ -179,7 +187,7 @@ pub(crate) async fn handle_reconnect(
     let mut last_err = KalshiError::Ws("websocket disconnected".to_string());
 
     loop {
-        if *shutdown_rx.borrow() {
+        if *shutdown_rx.borrow() || event_tx.is_closed() {
             return Ok(());
         }
 
@@ -194,11 +202,18 @@ pub(crate) async fn handle_reconnect(
         if !delay.is_zero() {
             tokio::select! {
                 _ = sleep(delay) => {}
+                _ = event_tx.closed() => {
+                    return Ok(());
+                }
                 changed = shutdown_rx.changed() => {
                     let _ = changed;
                     return Ok(());
                 }
             }
+        }
+
+        if event_tx.is_closed() {
+            return Ok(());
         }
 
         let reconnect_future = async {
@@ -211,6 +226,9 @@ pub(crate) async fn handle_reconnect(
         };
         let reconnect = tokio::select! {
             result = reconnect_future => result,
+            _ = event_tx.closed() => {
+                return Ok(());
+            }
             changed = shutdown_rx.changed() => {
                 let _ = changed;
                 return Ok(());
@@ -346,6 +364,73 @@ mod tests {
         assert!(matches!(second, WsEvent::Message(_)));
 
         server.await.expect("server");
+    }
+
+    #[tokio::test]
+    async fn reader_loop_exits_when_event_receiver_closes() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept 1");
+            let mut ws = accept_async(stream).await.expect("accept ws 1");
+            ws.send(Message::Text(ticker_frame("A", "1", 1, 1)))
+                .await
+                .expect("send 1");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            ws.send(Message::Text(ticker_frame("B", "2", 2, 2)))
+                .await
+                .expect("send 2");
+
+            timeout(Duration::from_millis(250), listener.accept())
+                .await
+                .is_ok()
+        });
+
+        let auth = load_test_auth();
+        let env = KalshiEnvironment {
+            rest_origin: Url::parse("http://127.0.0.1/").expect("url"),
+            ws_url: format!("ws://{}", addr),
+        };
+        let config = WsReconnectConfig {
+            max_retries: None,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(1),
+            jitter: 0.0,
+            resubscribe: false,
+        };
+        let client = KalshiWsLowLevelClient::connect_authenticated(env.clone(), auth.clone())
+            .await
+            .expect("connect");
+        let tracker = Arc::new(Mutex::new(SubscriptionTracker::default()));
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        let (_outgoing_tx, outgoing_rx) = mpsc::channel(1);
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let reader = tokio::spawn(reader_loop(
+            client,
+            env,
+            Some(auth),
+            config,
+            tracker,
+            event_tx,
+            outgoing_rx,
+            shutdown_rx,
+            WsReaderMode::Owned,
+        ));
+
+        let first = timeout(Duration::from_secs(2), event_rx.recv())
+            .await
+            .expect("timeout first")
+            .expect("first event");
+        assert!(matches!(first, WsEvent::Message(_)));
+        drop(event_rx);
+
+        timeout(Duration::from_secs(2), reader)
+            .await
+            .expect("reader should exit after receiver closes")
+            .expect("reader task should not panic");
+        assert!(!server.await.expect("server should not panic"));
     }
 
     #[tokio::test]

--- a/src/ws/reconnect.rs
+++ b/src/ws/reconnect.rs
@@ -18,6 +18,8 @@ use tokio::time::Duration;
 /// | `max_delay` | 30 s |
 /// | `jitter` | 0.2 |
 /// | `resubscribe` | `true` |
+/// | `ping_interval` | `None` (disabled) |
+/// | `pong_timeout` | 10 s |
 #[derive(Debug, Clone)]
 pub struct WsReconnectConfig {
     /// Maximum reconnection attempts. `None` means unlimited.
@@ -30,6 +32,13 @@ pub struct WsReconnectConfig {
     pub jitter: f64,
     /// Whether to resubscribe to active channels after reconnecting.
     pub resubscribe: bool,
+    /// Interval between client-originated `Ping` frames. `None` disables
+    /// keepalive, leaving reads without a deadline.
+    pub ping_interval: Option<Duration>,
+    /// How long to wait for any inbound frame after a ping before treating
+    /// the connection as dead and reconnecting. Only meaningful when
+    /// `ping_interval` is set.
+    pub pong_timeout: Duration,
 }
 
 impl Default for WsReconnectConfig {
@@ -40,6 +49,8 @@ impl Default for WsReconnectConfig {
             max_delay: Duration::from_secs(30),
             jitter: 0.2,
             resubscribe: true,
+            ping_interval: None,
+            pong_timeout: Duration::from_secs(10),
         }
     }
 }


### PR DESCRIPTION
## Summary
- **fix(ws):** dropping the `WsEvent` receiver no longer sends the reader into an infinite disconnect/reconnect churn loop — `event_tx.is_closed()`/`closed()` checks at every lifecycle decision point make the reader task exit cleanly, including waking immediately out of backoff sleeps and in-flight reconnect attempts
- **feat(ws), closes #47:** opt-in transport keepalive — `WsReconnectConfig.ping_interval: Option<Duration>` (default `None`, zero-cost when disabled via select preconditions) + `pong_timeout: Duration` (default 10s); a missed deadline becomes a transport error routed into the existing reconnect path; any inbound frame proves liveness and clears the deadline
- `low_level::next_frame` deliberately left timer-free (it's the transport under the managed reader; embedding timers would double-ping) — now documented, pointing callers at `tokio::time::timeout` or the managed client
- Version 0.6.1 + CHANGELOG

## Provenance note for reviewers
The receiver-drop fix is recovered code: it was found staged-but-never-committed in the working tree (orphan blob `a287bb6`), author unknown — see the forensic investigation. It applied to master byte-clean and is fully covered by its own test, but treat it as new, unreviewed code.

## Test Plan
- [x] `cargo test`: 69 lib + 89 integration + 11 doc, 0 failures
- [x] New tests: `reader_loop_exits_when_event_receiver_closes` (exit ≤2s, no reconnect attempt), `reader_keepalive_sends_pings`, `reader_keepalive_timeout_triggers_reconnect` (server swallows pings → second accept + `Reconnected` event), `reader_default_config_sends_no_pings`; keepalive tests ran 3x with no flakes
- [x] `cargo clippy --all-targets`: nothing new (4 known `WsOrderbookDelta::ts` deprecations)
- [x] Merge-order safe with open PR #48: neither touches the other's modified regions in `reader.rs`; Cargo.toml/CHANGELOG resolve trivially either way