### PR TITLE
Parse subscription shard_key as integer

### DIFF
--- a/src/ws/types/envelope.rs
+++ b/src/ws/types/envelope.rs
@@ -991,6 +991,44 @@ mod tests {
     }
 
     #[test]
+    fn ws_message_from_bytes_list_subscriptions_accepts_numeric_shard_key() {
+        let json = r#"{
+            "id":3,
+            "type":"ok",
+            "msg":[
+                {
+                    "channel":"communications",
+                    "sid":11,
+                    "shard_factor":4,
+                    "shard_key":2
+                }
+            ]
+        }"#;
+
+        let msg = WsMessageV2::from_bytes(json.as_bytes()).unwrap();
+        match msg {
+            WsMessageV2::ListSubscriptions { id, subscriptions } => {
+                assert_eq!(id, Some(3));
+                assert_eq!(subscriptions.len(), 1);
+                assert_eq!(subscriptions[0].shard_factor, Some(4));
+                assert_eq!(subscriptions[0].shard_key, Some(2));
+            }
+            other => panic!("expected list_subscriptions response, got {other:?}"),
+        }
+
+        let msg_ref = WsMessageRef::from_bytes(json.as_bytes()).unwrap();
+        match msg_ref {
+            WsMessageRef::ListSubscriptions { id, subscriptions } => {
+                assert_eq!(id, Some(3));
+                assert_eq!(subscriptions.len(), 1);
+                assert_eq!(subscriptions[0].shard_factor, Some(4));
+                assert_eq!(subscriptions[0].shard_key, Some(2));
+            }
+            other => panic!("expected borrowed list_subscriptions response, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn ws_message_from_bytes_unknown_type() {
         let json = r#"{"type":"mystery","msg":{"foo":1}}"#;
         let msg = WsMessageV2::from_bytes(json.as_bytes()).unwrap();

--- a/src/ws/types/subscription.rs
+++ b/src/ws/types/subscription.rs
@@ -73,7 +73,7 @@ pub struct WsSubscriptionInfo {
     #[serde(default)]
     pub shard_factor: Option<u32>,
     #[serde(default)]
-    pub shard_key: Option<String>,
+    pub shard_key: Option<u32>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -95,8 +95,8 @@ pub struct WsSubscriptionInfoRef<'a> {
     pub skip_ticker_ack: Option<bool>,
     #[serde(default)]
     pub shard_factor: Option<u32>,
-    #[serde(default, borrow)]
-    pub shard_key: Option<Cow<'a, str>>,
+    #[serde(default)]
+    pub shard_key: Option<u32>,
 }
 
 impl<'a> WsSubscriptionInfoRef<'a> {
@@ -117,7 +117,7 @@ impl<'a> WsSubscriptionInfoRef<'a> {
             send_initial_snapshot: self.send_initial_snapshot,
             skip_ticker_ack: self.skip_ticker_ack,
             shard_factor: self.shard_factor,
-            shard_key: self.shard_key.map(Cow::into_owned),
+            shard_key: self.shard_key,
         }
     }
 }


### PR DESCRIPTION
### Motivation
- The WebSocket `shard_key` is an integer in the Kalshi sharding contract but was modeled as a string in both owned and borrowed subscription types, causing deserialization to fail when `list_subscriptions`/`ok` payloads include numeric `shard_key` values.

### Description
- Change `WsSubscriptionInfo::shard_key` and `WsSubscriptionInfoRef::shard_key` from `Option<String>`/`Option<Cow<'a, str>>` to `Option<u32>` so numeric `shard_key` values deserialize correctly.
- Remove the borrowed `Cow` conversion and propagate the integer `shard_key` directly in `WsSubscriptionInfoRef::into_owned`.
- Add a regression test `ws_message_from_bytes_list_subscriptions_accepts_numeric_shard_key` that verifies both `WsMessageV2::from_bytes` and `WsMessageRef::from_bytes` successfully parse an `ok`/`list_subscriptions` payload containing a numeric `shard_key`.

### Testing
- Ran `cargo fmt --all -- --check`, which succeeded. 
- Ran `cargo test ws_message_from_bytes_list_subscriptions_accepts_numeric_shard_key`, which passed. 
- Ran the full test suite with `cargo test`: the new WebSocket regression passes, but the full suite reports existing unrelated REST client failures (mocked local HTTP calls returned `403 Forbidden` in this environment) that are not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c03d201348320a78fef4b9e660403)