### PR TITLE
Stop websocket reader when event receiver closes

### DIFF
--- a/src/ws/reader.rs
+++ b/src/ws/reader.rs
@@ -52,7 +52,7 @@ pub(crate) async fn reader_loop(
     let mut outgoing_closed = false;
 
     loop {
-        if *shutdown_rx.borrow() {
+        if *shutdown_rx.borrow() || event_tx.is_closed() {
             return;
         }
 
@@ -79,6 +79,10 @@ pub(crate) async fn reader_loop(
         };
 
         if let Err(_err) = result {
+            if event_tx.is_closed() {
+                return;
+            }
+
             match handle_reconnect(
                 &mut client,
                 &env,
@@ -90,7 +94,11 @@ pub(crate) async fn reader_loop(
             )
             .await
             {
-                Ok(()) => {}
+                Ok(()) => {
+                    if event_tx.is_closed() {
+                        return;
+                    }
+                }
                 Err(err) => {
                     if *shutdown_rx.borrow() {
                         return;
@@ -179,7 +187,7 @@ pub(crate) async fn handle_reconnect(
     let mut last_err = KalshiError::Ws("websocket disconnected".to_string());
 
     loop {
-        if *shutdown_rx.borrow() {
+        if *shutdown_rx.borrow() || event_tx.is_closed() {
             return Ok(());
         }
 
@@ -194,11 +202,18 @@ pub(crate) async fn handle_reconnect(
         if !delay.is_zero() {
             tokio::select! {
                 _ = sleep(delay) => {}
+                _ = event_tx.closed() => {
+                    return Ok(());
+                }
                 changed = shutdown_rx.changed() => {
                     let _ = changed;
                     return Ok(());
                 }
             }
+        }
+
+        if event_tx.is_closed() {
+            return Ok(());
         }
 
         let reconnect_future = async {
@@ -211,6 +226,9 @@ pub(crate) async fn handle_reconnect(
         };
         let reconnect = tokio::select! {
             result = reconnect_future => result,
+            _ = event_tx.closed() => {
+                return Ok(());
+            }
             changed = shutdown_rx.changed() => {
                 let _ = changed;
                 return Ok(());
@@ -346,6 +364,73 @@ mod tests {
         assert!(matches!(second, WsEvent::Message(_)));
 
         server.await.expect("server");
+    }
+
+    #[tokio::test]
+    async fn reader_loop_exits_when_event_receiver_closes() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept 1");
+            let mut ws = accept_async(stream).await.expect("accept ws 1");
+            ws.send(Message::Text(ticker_frame("A", "1", 1, 1)))
+                .await
+                .expect("send 1");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            ws.send(Message::Text(ticker_frame("B", "2", 2, 2)))
+                .await
+                .expect("send 2");
+
+            timeout(Duration::from_millis(250), listener.accept())
+                .await
+                .is_ok()
+        });
+
+        let auth = load_test_auth();
+        let env = KalshiEnvironment {
+            rest_origin: Url::parse("http://127.0.0.1/").expect("url"),
+            ws_url: format!("ws://{}", addr),
+        };
+        let config = WsReconnectConfig {
+            max_retries: None,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(1),
+            jitter: 0.0,
+            resubscribe: false,
+        };
+        let client = KalshiWsLowLevelClient::connect_authenticated(env.clone(), auth.clone())
+            .await
+            .expect("connect");
+        let tracker = Arc::new(Mutex::new(SubscriptionTracker::default()));
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        let (_outgoing_tx, outgoing_rx) = mpsc::channel(1);
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let reader = tokio::spawn(reader_loop(
+            client,
+            env,
+            Some(auth),
+            config,
+            tracker,
+            event_tx,
+            outgoing_rx,
+            shutdown_rx,
+            WsReaderMode::Owned,
+        ));
+
+        let first = timeout(Duration::from_secs(2), event_rx.recv())
+            .await
+            .expect("timeout first")
+            .expect("first event");
+        assert!(matches!(first, WsEvent::Message(_)));
+        drop(event_rx);
+
+        timeout(Duration::from_secs(2), reader)
+            .await
+            .expect("reader should exit after receiver closes")
+            .expect("reader task should not panic");
+        assert!(!server.await.expect("server should not panic"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Prevent the reader loop from entering an endless reconnect cycle when the `WsEventReceiver` is dropped and `event_tx.send(...)` fails. 
- Ensure reconnect backoff and reconnect attempts exit promptly when there is no event consumer, avoiding dangling sockets and wasted retries/CPU.

### Description
- Treat a closed `event_tx` as a terminal condition in `reader_loop` by checking `event_tx.is_closed()` before and after message handling and reconnect handling.
- Make `handle_reconnect` observe `event_tx` closure and wake/return during backoff and reconnect attempts by selecting on `event_tx.closed()` alongside the shutdown `watch` channel and sleep.
- Add a regression test `reader_loop_exits_when_event_receiver_closes` that drops the event receiver after the first message and verifies the reader task exits without attempting reconnect.
- Run `cargo fmt` formatting checks and updated `src/ws/reader.rs` accordingly.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran targeted reader tests with `cargo test reader_` which succeeded. 
- Ran full test suite with default env where some REST tests were affected by the environment proxy and initially returned `403`; re-running full tests with `NO_PROXY=localhost,127.0.0.1,::1 no_proxy=localhost,127.0.0.1,::1 cargo test` succeeded and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c03ec03ec8320bd38057aa58bc2e7)